### PR TITLE
Adds Bink Video support to Tiberian Sun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ COMMON_OBJS = \
               src/exception_catch.o \
               src/force_conversion_type.o \
               src/video_mode_hacks.o \
+              src/binkmovie/bink_load_dll.o \
+              src/binkmovie/bink_patches.o \
+              src/binkmovie/binkmovie.o \
               res/res.o \
               sym.o
 

--- a/inc/Classes/DSurface.h
+++ b/inc/Classes/DSurface.h
@@ -6,11 +6,11 @@ typedef struct DSurface DSurface;
 typedef struct {
     void *DSurface__Destroy;
     void *Dsurface_BlitWhole;
-    void *BlitPart;
+    void (__thiscall *BlitPart)(DSurface *this, RECT *torect, DSurface *fromsurface, RECT *fromrect, bool a4, bool a5);
     void *Blit;
     void *FillRectEx;
     void *FillRect;
-    void *Fill;
+    void (__thiscall *Fill)(DSurface *this, int color);
     void *sub48BCE0;
     void *sub6A7910;
     void *Put_Pixel;
@@ -32,8 +32,8 @@ typedef struct {
     void *Has_Focus;
     void *Is_Locked;
     int32_t (__thiscall *Get_BytesPerPixel)(DSurface *this);
-    void *Get_Pitch;
-    void *Get_Rect;
+    int32_t (__thiscall *Get_Pitch)(DSurface *this);
+    RECT (__thiscall *Get_Rect)(DSurface *this, RECT *__hidden_ret);
     int32_t (__thiscall *Get_Width)(DSurface *this);
     int32_t (__thiscall *Get_Height)(DSurface *this);
     void *sub4901C0;
@@ -55,7 +55,8 @@ typedef struct DSurface {
     char    InVideoMemory;
     char    Unknown;
     char    Unknown2;
-    DDSURFACEDESC *SurfaceDesc;
+	LPDIRECTDRAWSURFACE VideoSurfacePtr; // Pointer to the related direct draw surface.
+	LPDDSURFACEDESC VideoSurfaceDescription; // Description of the said surface.
 } DSurface;
 
 extern DSurface *PrimarySurface;

--- a/inc/Enums/KeyboardTypes.h
+++ b/inc/Enums/KeyboardTypes.h
@@ -1,0 +1,583 @@
+//
+// Constants for WWKeyboardClass.
+//
+// Author: CCHyper
+// Date: 28-03-2021
+//
+#ifndef _KEYBOARD_TYPES_H_
+#define _KEYBOARD_TYPES_H_
+
+#include <windows.h>
+//#include <Winuser.h>
+
+
+// GetKeyState flags
+#define DEFUALT_KEY_UP 0x0
+#define DEFUALT_KEY_DOWN 0x80
+#define TOGGLED_KEY_ON 0x1
+#define TOGGLED_KEY_OFF 0x81
+
+
+// Modifiers
+#define SHIFT_KEY_PRESSED 0x100
+#define CTRL_KEY_PRESSED 0x200
+#define ALT_KEY_PRESSED 0x400
+#define WIN_KEY_PRESSED 0x800
+#define NUMLOCK_KEY_PRESSED 0x200
+#define SCROLL_KEY_PRESSED 0x200
+
+
+// Windows virtual keys.
+#define VK_NONE 0x00
+#define VK_LBUTTON 0x01
+#define VK_RBUTTON 0x02
+#define VK_CANCEL 0x03
+#define VK_MBUTTON 0x04
+#define VK_NONE_05 0x05
+#define VK_NONE_06 0x06
+#define VK_NONE_07 0x07
+#define VK_BACK 0x08
+#define VK_TAB 0x09
+#define VK_NONE_0A 0x0A
+#define VK_NONE_0B 0x0B
+#define VK_CLEAR 0x0C
+#define VK_RETURN 0x0D
+#define VK_NONE_0E 0x0E
+#define VK_NONE_0F 0x0F
+#define VK_SHIFT 0x10
+#define VK_CONTROL 0x11
+#define VK_MENU 0x12
+#define VK_PAUSE 0x13
+#define VK_CAPITAL 0x14
+#define VK_NONE_15 0x15
+#define VK_NONE_16 0x16
+#define VK_NONE_17 0x17
+#define VK_NONE_18 0x18
+#define VK_NONE_19 0x19
+#define VK_NONE_1A 0x1A
+#define VK_ESCAPE 0x1B
+#define VK_NONE_1C 0x1C
+#define VK_NONE_1D 0x1D
+#define VK_NONE_1E 0x1E
+#define VK_NONE_1F 0x1F
+#define VK_SPACE 0x20
+#define VK_PRIOR 0x21
+#define VK_NEXT 0x22
+#define VK_END 0x23
+#define VK_HOME 0x24
+#define VK_LEFT 0x25
+#define VK_UP 0x26
+#define VK_RIGHT 0x27
+#define VK_DOWN 0x28
+#define VK_SELECT 0x29
+#define VK_PRINT 0x2A
+#define VK_EXECUTE 0x2B
+#define VK_SNAPSHOT 0x2C
+#define VK_INSERT 0x2D
+#define VK_DELETE 0x2E
+#define VK_HELP 0x2F
+#define VK_0 0x30
+#define VK_1 0x31
+#define VK_2 0x32
+#define VK_3 0x33
+#define VK_4 0x34
+#define VK_5 0x35
+#define VK_6 0x36
+#define VK_7 0x37
+#define VK_8 0x38
+#define VK_9 0x39
+#define VK_NONE_3B 0x3B
+#define VK_NONE_3C 0x3C
+#define VK_NONE_3D 0x3D
+#define VK_NONE_3E 0x3E
+#define VK_NONE_3F 0x3F
+#define VK_NONE_40 0x40
+#define VK_A 0x41
+#define VK_B 0x42
+#define VK_C 0x43
+#define VK_D 0x44
+#define VK_E 0x45
+#define VK_F 0x46
+#define VK_G 0x47
+#define VK_H 0x48
+#define VK_I 0x49
+#define VK_J 0x4A
+#define VK_K 0x4B
+#define VK_L 0x4C
+#define VK_M 0x4D
+#define VK_N 0x4E
+#define VK_O 0x4F
+#define VK_P 0x50
+#define VK_Q 0x51
+#define VK_R 0x52
+#define VK_S 0x53
+#define VK_T 0x54
+#define VK_U 0x55
+#define VK_V 0x56
+#define VK_W 0x57
+#define VK_X 0x58
+#define VK_Y 0x59
+#define VK_Z 0x5A
+#define VK_NONE_5B 0x5B
+#define VK_NONE_5C 0x5C
+#define VK_NONE_5D 0x5D
+#define VK_NONE_5E 0x5E
+#define VK_NONE_5F 0x5F
+#define VK_NUMPAD0 0x60
+#define VK_NUMPAD1 0x61
+#define VK_NUMPAD2 0x62
+#define VK_NUMPAD3 0x63
+#define VK_NUMPAD4 0x64
+#define VK_NUMPAD5 0x65
+#define VK_NUMPAD6 0x66
+#define VK_NUMPAD7 0x67
+#define VK_NUMPAD8 0x68
+#define VK_NUMPAD9 0x69
+#define VK_MULTIPLY 0x6A
+#define VK_ADD 0x6B
+#define VK_SEPARATOR 0x6C
+#define VK_SUBTRACT 0x6D
+#define VK_DECIMAL 0x6E
+#define VK_DIVIDE 0x6F
+#define VK_F1 0x70
+#define VK_F2 0x71
+#define VK_F3 0x72
+#define VK_F4 0x73
+#define VK_F5 0x74
+#define VK_F6 0x75
+#define VK_F7 0x76
+#define VK_F8 0x77
+#define VK_F9 0x78
+#define VK_F10 0x79
+#define VK_F11 0x7A
+#define VK_F12 0x7B
+#define VK_F13 0x7C
+#define VK_F14 0x7D
+#define VK_F15 0x7E
+#define VK_F16 0x7F
+#define VK_F17 0x80
+#define VK_F18 0x81
+#define VK_F19 0x82
+#define VK_F20 0x83
+#define VK_F21 0x84
+#define VK_F22 0x85
+#define VK_F23 0x86
+#define VK_F24 0x87
+#define VK_NONE_88 0x88
+#define VK_NONE_89 0x89
+#define VK_NONE_8A 0x8A
+#define VK_NONE_8B 0x8B
+#define VK_NONE_8C 0x8C
+#define VK_NONE_8D 0x8D
+#define VK_NONE_8E 0x8E
+#define VK_NONE_8F 0x8F
+#define VK_NUMLOCK 0x90
+#define VK_SCROLL 0x91
+#define VK_NONE_92 0x92
+#define VK_NONE_93 0x93
+#define VK_NONE_94 0x94
+#define VK_NONE_95 0x95
+#define VK_NONE_96 0x96
+#define VK_NONE_97 0x97
+#define VK_NONE_98 0x98
+#define VK_NONE_99 0x99
+#define VK_NONE_9A 0x9A
+#define VK_NONE_9B 0x9B
+#define VK_NONE_9C 0x9C
+#define VK_NONE_9D 0x9D
+#define VK_NONE_9E 0x9E
+#define VK_NONE_9F 0x9F
+#define VK_NONE_A0 0xA0
+#define VK_NONE_A1 0xA1
+#define VK_NONE_A2 0xA2
+#define VK_NONE_A3 0xA3
+#define VK_NONE_A4 0xA4
+#define VK_NONE_A5 0xA5
+#define VK_NONE_A6 0xA6
+#define VK_NONE_A7 0xA7
+#define VK_NONE_A8 0xA8
+#define VK_NONE_A9 0xA9
+#define VK_NONE_AA 0xAA
+#define VK_NONE_AB 0xAB
+#define VK_NONE_AC 0xAC
+#define VK_NONE_AD 0xAD
+#define VK_NONE_AE 0xAE
+#define VK_NONE_AF 0xAF
+#define VK_NONE_B0 0xB0
+#define VK_NONE_B1 0xB1
+#define VK_NONE_B2 0xB2
+#define VK_NONE_B3 0xB3
+#define VK_NONE_B4 0xB4
+#define VK_NONE_B5 0xB5
+#define VK_NONE_B6 0xB6
+#define VK_NONE_B7 0xB7
+#define VK_NONE_B8 0xB8
+#define VK_NONE_B9 0xB9
+#define VK_NONE_BA 0xBA // ;
+#define VK_NONE_BB 0xBB // =
+#define VK_NONE_BC 0xBC // ,
+#define VK_NONE_BD 0xBD // -
+#define VK_NONE_BE 0xBE // .
+#define VK_NONE_BF 0xBF // /
+#define VK_NONE_C0 0xC0 // `
+#define VK_NONE_C1 0xC1
+#define VK_NONE_C2 0xC2
+#define VK_NONE_C3 0xC3
+#define VK_NONE_C4 0xC4
+#define VK_NONE_C5 0xC5
+#define VK_NONE_C6 0xC6
+#define VK_NONE_C7 0xC7
+#define VK_NONE_C8 0xC8
+#define VK_NONE_C9 0xC9
+#define VK_NONE_CA 0xCA
+#define VK_NONE_CB 0xCB
+#define VK_NONE_CC 0xCC
+#define VK_NONE_CD 0xCD
+#define VK_NONE_CE 0xCE
+#define VK_NONE_CF 0xCF
+#define VK_NONE_D0 0xD0
+#define VK_NONE_D1 0xD1
+#define VK_NONE_D2 0xD2
+#define VK_NONE_D3 0xD3
+#define VK_NONE_D4 0xD4
+#define VK_NONE_D5 0xD5
+#define VK_NONE_D6 0xD6
+#define VK_NONE_D7 0xD7
+#define VK_NONE_D8 0xD8
+#define VK_NONE_D9 0xD9
+#define VK_NONE_DA 0xDA
+#define VK_NONE_DB 0xDB  // [
+#define VK_NONE_DC 0xDC  // '\'
+#define VK_NONE_DD 0xDD  // ]
+#define VK_NONE_DE 0xDE  // '
+#define VK_NONE_DF 0xDF
+#define VK_NONE_E0 0xE0
+#define VK_NONE_E1 0xE1
+#define VK_NONE_E2 0xE2
+#define VK_NONE_E3 0xE3
+#define VK_NONE_E4 0xE4
+#define VK_NONE_E5 0xE5
+#define VK_NONE_E6 0xE6
+#define VK_NONE_E7 0xE7
+#define VK_NONE_E8 0xE8
+#define VK_NONE_E9 0xE9
+#define VK_NONE_EA 0xEA
+#define VK_NONE_EB 0xEB
+#define VK_NONE_EC 0xEC
+#define VK_NONE_ED 0xED
+#define VK_NONE_EE 0xEE
+#define VK_NONE_EF 0xEF
+#define VK_NONE_F0 0xF0
+#define VK_NONE_F1 0xF1
+#define VK_NONE_F2 0xF2
+#define VK_NONE_F3 0xF3
+#define VK_NONE_F4 0xF4
+#define VK_NONE_F5 0xF5
+#define VK_NONE_F6 0xF6
+#define VK_NONE_F7 0xF7
+#define VK_NONE_F8 0xF8
+#define VK_NONE_F9 0xF9
+#define VK_NONE_FA 0xFA
+#define VK_NONE_FB 0xFB
+#define VK_NONE_FC 0xFC
+#define VK_NONE_FD 0xFD
+#define VK_NONE_FE 0xFE
+#define VK_NONE_FF 0xFF
+
+#define VK_UPLEFT VK_HOME
+#define VK_UPRIGHT VK_PRIOR
+#define VK_DOWNLEFT VK_END
+#define VK_DOWNRIGHT VK_NEXT
+#define VK_ALT VK_MENU
+
+
+typedef enum WWKey_Type
+{
+    WWKEY_SHIFT_BIT = 0x100,
+    WWKEY_CTRL_BIT = 0x200,
+    WWKEY_ALT_BIT = 0x400,
+    WWKEY_RLS_BIT = 0x800,
+    WWKEY_VK_BIT = 0x1000,
+    WWKEY_DBL_BIT = 0x2000,
+    WWKEY_BTN_BIT = 0x8000,
+} WWKey_Type;
+
+
+typedef enum KeyASCIIType
+{
+    //
+    // Define all the KA types as variations of the VK types.  This is
+    // so the KA functions will work properly under Windows.
+    //
+    KA_NONE = 0,
+    KA_MORE = 1,
+    KA_SETBKGDCOL = 2,
+    KA_SETFORECOL = 6,
+    KA_FORMFEED = 12,
+    KA_SPCTAB = 20,
+    KA_SETX = 25,
+    KA_SETY = 26,
+    
+    KA_SPACE = 32, //  
+    KA_EXCLAMATION, // !
+    KA_DQUOTE, // "
+    KA_POUND, // #
+    KA_DOLLAR, // $
+    KA_PERCENT, // %
+    KA_AMPER, // &
+    KA_SQUOTE, // '
+    KA_LPAREN, // (
+    KA_RPAREN, // )
+    KA_ASTERISK, // *
+    KA_PLUS, // +
+    KA_COMMA, // ,
+    KA_MINUS, // -
+    KA_PERIOD, // .
+    KA_SLASH, // /
+    
+    KA_0,
+    KA_1,
+    KA_2,
+    KA_3,
+    KA_4,
+    KA_5,
+    KA_6,
+    KA_7,
+    KA_8,
+    KA_9,
+    KA_COLON, // :
+    KA_SEMICOLON, // ;
+    KA_LESS_THAN, // <
+    KA_EQUAL, // =
+    KA_GREATER_THAN, // >
+    KA_QUESTION, // ?
+    
+    KA_AT, // @
+    KA_A, // A
+    KA_B, // B
+    KA_C, // C
+    KA_D, // D
+    KA_E, // E
+    KA_F, // F
+    KA_G, // G
+    KA_H, // H
+    KA_I, // I
+    KA_J, // J
+    KA_K, // K
+    KA_L, // L
+    KA_M, // M
+    KA_N, // N
+    KA_O, // O
+    
+    KA_P, // P
+    KA_Q, // Q
+    KA_R, // R
+    KA_S, // S
+    KA_T, // T
+    KA_U, // U
+    KA_V, // V
+    KA_W, // W
+    KA_X, // X
+    KA_Y, // Y
+    KA_Z, // Z
+    KA_LBRACKET, // [
+    KA_BACKSLASH, // "\"
+//    KA_RBRACKET, // ]
+    KA_CARROT, // ^
+    KA_UNDERLINE, // _
+    
+    KA_GRAVE, // `
+    KA_a, // a
+    KA_b, // b
+    KA_c, // c
+    KA_d, // d
+    KA_e, // e
+    KA_f, // f
+    KA_g, // g
+    KA_h, // h
+    KA_i, // i
+    KA_j, // j
+    KA_k, // k
+    KA_l, // l
+    KA_m, // m
+    KA_n, // n
+    KA_o, // o
+    
+    KA_p, // p
+    KA_q, // q
+    KA_r, // r
+    KA_s, // s
+    KA_t, // t
+    KA_u, // u
+    KA_v, // v
+    KA_w, // w
+    KA_x, // x
+    KA_y, // y
+    KA_z, // z
+    KA_LBRACE, // {
+    KA_BAR, // |
+    KA_RBRACE, // ]
+    KA_TILDA, // ~
+    
+    KA_ESC = VK_ESCAPE,
+    KA_EXTEND = VK_ESCAPE,
+    KA_RETURN = VK_RETURN,
+    KA_BACKSPACE = VK_BACK,
+    KA_TAB = VK_TAB,
+    KA_DELETE = VK_DELETE, // <DELETE>
+    KA_INSERT = VK_INSERT, // <INSERT>
+    KA_PGDN = VK_NEXT, // <PAGE DOWN>
+    KA_DOWNRIGHT = VK_NEXT,
+    KA_DOWN = VK_DOWN, // <DOWN ARROW>
+    KA_END = VK_END, // <END>
+    KA_DOWNLEFT = VK_END,
+    KA_RIGHT = VK_RIGHT, // <RIGHT ARROW>
+    KA_KEYPAD5 = VK_SELECT, // NUMERIC KEY PAD <5>
+    KA_LEFT = VK_LEFT, // <LEFT ARROW>
+    KA_PGUP = VK_PRIOR, // <PAGE UP>
+    KA_UPRIGHT = VK_PRIOR,
+    KA_UP = VK_UP, // <UP ARROW>
+    KA_HOME = VK_HOME, // <HOME>
+    KA_UPLEFT = VK_HOME,
+    KA_F12 = VK_F12,
+    KA_F11 = VK_F11,
+    KA_F10 = VK_F10,
+    KA_F9 = VK_F9,
+    KA_F8 = VK_F8,
+    KA_F7 = VK_F7,
+    KA_F6 = VK_F6,
+    KA_F5 = VK_F5,
+    KA_F4 = VK_F4,
+    KA_F3 = VK_F3,
+    KA_F2 = VK_F2,
+    KA_F1 = VK_F1,
+    KA_LMOUSE = VK_LBUTTON,
+    KA_RMOUSE = VK_RBUTTON,
+    
+    KA_SHIFT_BIT = WWKEY_SHIFT_BIT,
+    KA_CTRL_BIT = WWKEY_CTRL_BIT,
+    KA_ALT_BIT = WWKEY_ALT_BIT,
+    KA_RLSE_BIT = WWKEY_RLS_BIT,
+} KeyASCIIType;
+
+
+typedef enum KeyNumType
+{
+    KN_NONE = 0,
+
+    KN_0 = VK_0,
+    KN_1 = VK_1,
+    KN_2 = VK_2,
+    KN_3 = VK_3,
+    KN_4 = VK_4,
+    KN_5 = VK_5,
+    KN_6 = VK_6,
+    KN_7 = VK_7,
+    KN_8 = VK_8,
+    KN_9 = VK_9,
+    KN_A = VK_A,
+    KN_B = VK_B,
+    KN_BACKSLASH = VK_NONE_DC,
+    KN_BACKSPACE = VK_BACK,
+    KN_C = VK_C,
+    KN_CAPSLOCK = VK_CAPITAL,
+    KN_CENTER = VK_CLEAR,
+    KN_COMMA = VK_NONE_BC,
+    KN_D = VK_D,
+    KN_DELETE = VK_DELETE,
+    KN_DOWN = VK_DOWN,
+    KN_DOWNLEFT = VK_END,
+    KN_DOWNRIGHT = VK_NEXT,
+    KN_E = VK_E,
+    KN_END = VK_END,
+    KN_EQUAL = VK_NONE_BB,
+    KN_ESC = VK_ESCAPE,
+    KN_E_DELETE = VK_DELETE,
+    KN_E_DOWN = VK_NUMPAD2,
+    KN_E_END = VK_NUMPAD1,
+    KN_E_HOME = VK_NUMPAD7,
+    KN_E_INSERT = VK_INSERT,
+    KN_E_LEFT = VK_NUMPAD4,
+    KN_E_PGDN = VK_NUMPAD3,
+    KN_E_PGUP = VK_NUMPAD9,
+    KN_E_RIGHT = VK_NUMPAD6,
+    KN_E_UP = VK_NUMPAD8,
+    KN_F = VK_F,
+    KN_F1 = VK_F1,
+    KN_F10 = VK_F10,
+    KN_F11 = VK_F11,
+    KN_F12 = VK_F12,
+    KN_F2 = VK_F2,
+    KN_F3 = VK_F3,
+    KN_F4 = VK_F4,
+    KN_F5 = VK_F5,
+    KN_F6 = VK_F6,
+    KN_F7 = VK_F7,
+    KN_F8 = VK_F8,
+    KN_F9 = VK_F9,
+    KN_G = VK_G,
+    KN_GRAVE = VK_NONE_C0,
+    KN_H = VK_H,
+    KN_HOME = VK_HOME,
+    KN_I = VK_I,
+    KN_INSERT = VK_INSERT,
+    KN_J = VK_J,
+    KN_K = VK_K,
+    KN_KEYPAD_ASTERISK = VK_MULTIPLY,
+    KN_KEYPAD_MINUS = VK_SUBTRACT,
+    KN_KEYPAD_PLUS = VK_ADD,
+    KN_KEYPAD_RETURN = VK_RETURN,
+    KN_KEYPAD_SLASH = VK_DIVIDE,
+    KN_L = VK_L,
+    KN_LALT = VK_MENU,
+    KN_LBRACKET = VK_NONE_DB,
+    KN_LCTRL = VK_CONTROL,
+    KN_LEFT = VK_LEFT,
+    KN_LMOUSE = VK_LBUTTON,
+    KN_LSHIFT = VK_SHIFT,
+    KN_M = VK_M,
+    KN_MINUS = VK_NONE_BD,
+    KN_N = VK_N,
+    KN_NUMLOCK = VK_NUMLOCK,
+    KN_O = VK_O,
+    KN_P = VK_P,
+    KN_PAUSE = VK_PAUSE,
+    KN_PERIOD = VK_NONE_BE,
+    KN_PGDN = VK_NEXT,
+    KN_PGUP = VK_PRIOR,
+    KN_PRNTSCRN = VK_PRINT,
+    KN_Q = VK_Q,
+    KN_R = VK_R,
+    KN_RALT = VK_MENU,
+    KN_RBRACKET = VK_NONE_DD,
+    KN_RCTRL = VK_CONTROL,
+    KN_RETURN = VK_RETURN,
+    KN_RIGHT = VK_RIGHT,
+    KN_RMOUSE = VK_RBUTTON,
+    KN_RSHIFT = VK_SHIFT,
+    KN_S = VK_S,
+    KN_SCROLLLOCK = VK_SCROLL,
+    KN_SEMICOLON = VK_NONE_BA,
+    KN_SLASH = VK_NONE_BF,
+    KN_SPACE = VK_SPACE,
+    KN_SQUOTE = VK_NONE_DE,
+    KN_T = VK_T,
+    KN_TAB = VK_TAB,
+    KN_U = VK_U,
+    KN_UP = VK_UP,
+    KN_UPLEFT = VK_HOME,
+    KN_UPRIGHT = VK_PRIOR,
+    KN_V = VK_V,
+    KN_W = VK_W,
+    KN_X = VK_X,
+    KN_Y = VK_Y,
+    KN_Z = VK_Z,
+
+    KN_SHIFT_BIT = WWKEY_SHIFT_BIT,
+    KN_CTRL_BIT = WWKEY_CTRL_BIT,
+    KN_ALT_BIT = WWKEY_ALT_BIT,
+    KN_RLSE_BIT = WWKEY_RLS_BIT,
+    KN_BUTTON = WWKEY_BTN_BIT,
+} KeyNumType;
+
+#endif

--- a/inc/TiberianSun.h
+++ b/inc/TiberianSun.h
@@ -315,16 +315,8 @@ void WWDebug_Printf(char *fmt, ...);
 int32_t __thiscall Random2Class__operator(void *self, int32_t a2, int32_t a3);
 int32_t _sprintf(char *dest, char *format, ...);
 size_t __strcmpi(const char *, const char *);
-//void *memcpy(char *dest, const char *src, size_t len);
-//char *__cdecl _strupr(char *String);
-//char *__cdecl _strstr(const char *Str, const char *SubStr);
-//char *__cdecl strchr(const char *Str, int Val);
 char *__cdecl strncpy(char *Dest, const char *Source, size_t Count);
 
-//HMODULE __stdcall LoadLibraryA(LPCSTR lpLibFileName);
-//DWORD __stdcall GetFileAttributesA(LPCSTR lpFileName);
-//FARPROC __stdcall GetProcAddress(HMODULE hModule, LPCSTR lpProcName);
-//BOOL __stdcall GetClientRect(HWND hWnd, LPRECT lpRect);
 
 // ### Variables ###
 

--- a/inc/TiberianSun.h
+++ b/inc/TiberianSun.h
@@ -6,6 +6,7 @@
 #include <windows.h>
 #include "Enums/RTTIType.h"
 #include "Enums/EventTypes.h"
+#include "Enums/KeyboardTypes.h"
 #include "TopLevelTypes.h"
 #include "CommandClasses.h"
 #include "Classes/AbstractClass.h"
@@ -28,8 +29,11 @@
 #include "Classes/EventClass.h"
 #include "Classes/DSurface.h"
 
+#define CLAMP(x, min, max) (x < min ? min : x > max ? max : x)
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
+
+#define GAME_CAMPAIGN 0
 
 // This header works with sym.asm which defines the Vanilla symbols
 // This header will be split up as it becomes larger
@@ -94,6 +98,7 @@ extern DynamicVectorClass_Houses HouseClassArray;
 extern SessionClass SessionType;
 extern SessionClass SessionClass_this;
 extern WWKeyboardClass *WWKeyboard;
+extern WWMouseClass *WWMouse;
 extern uint32_t ForceFire1;
 extern uint32_t ForceFire2;
 extern MessageListClass MessageListClass_this;
@@ -108,6 +113,7 @@ extern DSurface *SidebarSurface;
 extern DSurface *TempSurface;
 extern DSurface *CompositeSurface;
 extern DSurface *AlternateSurface;
+extern DSurface *HiddenSurface;
 extern StripClass RIGHT_STRIP;
 extern StripClass LEFT_STRIP;
 extern Rect SidebarLoc;
@@ -133,9 +139,15 @@ extern int32_t DoingAutoSS;
 extern int DumpDebugInfoFrame;
 extern int GameSpeed;
 extern int GameOptionsClass_GameSpeed;
+extern int GameOptionsClass_VoiceVolume;
+extern int GameOptionsClass_ScreenWidth;
+extern int GameOptionsClass_ScreenHeight;
 extern int RequestedFPS;
 extern int NormalizedDelayGameSpeed;
 extern int ScenarioInit;
+extern int GameInFocus;
+extern HWND MainWindow;
+extern bool Debug_Quiet;
 
 // ### Functions ###
 void Queue_Options();
@@ -148,6 +160,11 @@ void   __thiscall FileClass__dtor(FileClass *fileClass);
 int    __thiscall FileClass__Write(FileClass *fileClass, void *buf, size_t len);
 bool   __thiscall FileClass__Open(FileClass *fileClass, int mode);
 
+void   __thiscall RawFileClass__RawFileClass(RawFileClass *rawfile, char *name);
+bool   __thiscall RawFileClass__Is_Available(RawFileClass *rawfile, bool force);
+bool   __thiscall RawFileCalss__Create(RawFileClass *rawfile);
+void   __thiscall RawFileClass__Destroy(RawFileClass *rawfile);
+
 void   __thiscall CCFileClass__CCFileClass(CCFileClass *ccfile, char *name);
 bool   __thiscall CCFileClass__Is_Available(CCFileClass *ccfile, bool force);
 size_t __thiscall CCFileClass__Size(CCFileClass *ccfile);
@@ -156,7 +173,6 @@ int    __thiscall CCFileClass__Write(CCFileClass *fileClass, void *buf, size_t l
 void   __thiscall CCFileClass__Destroy(CCFileClass *ccfile);
 bool   __thiscall CCFileClass__Open(CCFileClass *fileClass, int mode);
 void   __thiscall CCFileClass__Close(CCFileClass);
-bool   __thiscall RawFileCalss__Create(RawFileClass *file);
 
 bool __thiscall INIClass__GetBool(INIClass iniClass, char *section, char *key, bool defaultValue);
 int  __thiscall INIClass__GetInt(INIClass iniClass, char *section, char *key, int defaultValue);
@@ -194,13 +210,19 @@ void MapClass__Reveal_The_Map();
 void __thiscall MapClass__Fill_Map_With_Fog(MouseClass *this);
 void __thiscall GScreenClass__Input(MouseClass *Map, int, int, int);
 void __thiscall GScreenClass__Render(MouseClass *Map);
-void __thiscall GScreenClass__Flag_To_Redraw(MouseClass *Map);
+void __thiscall GScreenClass__Flag_To_Redraw(MouseClass *Map, int flag);
+void __fastcall GScreenClass__Do_Blit(bool a1, DSurface *surface, bool a2);
 void __thiscall SidebarClass__StripClass__Flag_To_Redraw(void *this);
 void __thiscall SidebarClass__Blit(void *this, char a2);
 void __thiscall SidebarClass__Draw_It(MouseClass *Map, char a2);
 void __thiscall SidebarClass__Init_IO(MouseClass *this);
 void __thiscall SidebarClass__Init_For_House(MouseClass *this);
 void __thiscall DisplayClass__Init_IO(void *this);
+
+void __fastcall Play_Movie(char *filename, int theme, bool a3, bool a4, bool a5);
+
+void __fastcall Emergency_Exit();
+void __cdecl exit(int code);
 
 extern __fastcall void
 CC_Draw_Shape(DSurface *surface, void *palette, Image *image, int32_t frame,
@@ -265,9 +287,21 @@ void *__cdecl operator_new(size_t size);
 void __cdecl operator_delete(void *memory);
 
 bool __thiscall WWKeyboardClass__Down(WWKeyboardClass *this, uint32_t key);
+void __thiscall WWKeyboardClass__Clear(WWKeyboardClass *this);
+unsigned short __thiscall WWKeyboardClass__Check(WWKeyboardClass *this);
+unsigned short __thiscall WWKeyboardClass__Get(WWKeyboardClass *this);
 void __fastcall PrettyPrintKey(int16_t code, char *buf);
 
+void __thiscall WWMouseClass__Show_Mouse(WWMouseClass *this);
+void __thiscall WWMouseClass__Hide_Mouse(WWMouseClass *this);
+
+bool __fastcall MixFileClass__Offset(const char * filename, void ** realptr, MixFileClass ** mixfile, long * offset, long * size);
+
+bool __fastcall VQA_Windows_Message_Loop(void);
+
 void __thiscall Print_CRCs(int a1);
+
+RECT __fastcall Rect_Intersect(RECT *rect1, RECT *rect2, int *x, int *y);
 
 LRESULT CALLBACK WndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
@@ -282,6 +316,16 @@ int32_t __thiscall Random2Class__operator(void *self, int32_t a2, int32_t a3);
 int32_t _sprintf(char *dest, char *format, ...);
 size_t __strcmpi(const char *, const char *);
 //void *memcpy(char *dest, const char *src, size_t len);
+//char *__cdecl _strupr(char *String);
+//char *__cdecl _strstr(const char *Str, const char *SubStr);
+//char *__cdecl strchr(const char *Str, int Val);
+char *__cdecl strncpy(char *Dest, const char *Source, size_t Count);
+
+//HMODULE __stdcall LoadLibraryA(LPCSTR lpLibFileName);
+//DWORD __stdcall GetFileAttributesA(LPCSTR lpFileName);
+//FARPROC __stdcall GetProcAddress(HMODULE hModule, LPCSTR lpProcName);
+//BOOL __stdcall GetClientRect(HWND hWnd, LPRECT lpRect);
+
 // ### Variables ###
 
 extern bool VideoWindowed;
@@ -334,3 +378,8 @@ LONG WINAPI Top_Level_Exception_Filter(struct _EXCEPTION_POINTERS *ExceptionInfo
 LONG __fastcall PrintException(int id, struct _EXCEPTION_POINTERS *ExceptionInfo);
 
 void *new(int32_t);
+
+#include <dsound.h>
+		
+extern LPDIRECTSOUND DSAudio_SoundObject;
+extern bool DSAudio_AudioDone;

--- a/inc/TiberianSun.inc
+++ b/inc/TiberianSun.inc
@@ -74,6 +74,9 @@ cextern FileClass__Is_Available
 cextern FileClass__Open
 cextern FileClass__Close
 cextern FileClass__Write
+cextern RawFileClass__FileClass
+cextern RawFileClass__Is_Available
+cextern RawFileClass__Destroy
 cextern CCFileClass__CCFileClass
 cextern CCFileClass__Destroy
 
@@ -261,6 +264,9 @@ cextern VisibleRect__Width
 cextern VisibleRect__Height
 cextern WWKeyboard
 cextern WWKeyboardClass__Down
+cextern WWKeyboardClass__Clear
+cextern WWKeyboardClass__Check
+cextern WWKeyboardClass__Get
 cextern Left_Shift_Key
 cextern Right_Shift_Key
 cextern Left_Alt_Key

--- a/inc/TiberianSun_Structures.h
+++ b/inc/TiberianSun_Structures.h
@@ -267,6 +267,30 @@ typedef struct WWKeyboardClass
 
 
 #pragma pack(push, 1)
+typedef struct WWMouseClass
+{
+} WWMouseClass;
+#pragma pack(pop)
+
+
+#pragma pack(push, 4)
+typedef struct MixFileClass
+{
+	char GenericNode[0xC];
+	char *Filename;
+	bool IsDigest;
+	bool IsEncrypted;
+	bool IsAllocated;
+	int Count;
+	int DataSize;
+	int DataStart;
+	void *HeaderBuffer;
+	void *Data;
+} MixFileClass;
+#pragma pack(pop)
+
+
+#pragma pack(push, 1)
 typedef struct Matrix3D
 {
   float field_0;

--- a/inc/macros/patch.h
+++ b/inc/macros/patch.h
@@ -47,3 +47,11 @@
         ".long 4;"                                  \
         ".long " #value ";"                         \
     )
+	
+#define SETBYTE(dst, value)                         \
+    __asm (                                         \
+        ".section .patch,\"d0\";"                   \
+        ".long " #dst ";"                           \
+        ".long 1;"                                  \
+        ".byte " #value ";"                         \
+    )

--- a/src/binkmovie/bink.h
+++ b/src/binkmovie/bink.h
@@ -1,0 +1,208 @@
+//
+// Header containing bare basic structures and types required for interacting
+// with the BinkW32 library.
+//
+// Author: CCHyper
+//
+ 
+#ifndef _BINK_HEADER_H_
+#define _BINK_HEADER_H_
+
+
+typedef struct BINK * HBINK;
+
+struct BINKSND;
+
+typedef int (__stdcall *BINKSNDOPEN) (struct BINKSND *BnkSnd, unsigned int freq, int bits, int chans, int flags, HBINK bink);
+typedef BINKSNDOPEN (__stdcall *BINKSNDSYSOPEN)(unsigned int param);
+typedef void (__stdcall * BINKSNDRESET) (struct BINKSND *BnkSnd);
+typedef int (__stdcall * BINKSNDREADY) (struct BINKSND *BnkSnd);
+typedef int (__stdcall * BINKSNDLOCK) (struct BINKSND *BnkSnd, unsigned char **addr, unsigned int *len);
+typedef int (__stdcall * BINKSNDUNLOCK) (struct BINKSND *BnkSnd, unsigned int filled);
+typedef void (__stdcall * BINKSNDVOLUME) (struct BINKSND *BnkSnd, int volume);
+typedef void (__stdcall * BINKSNDPAN) (struct BINKSND *BnkSnd, int pan);
+typedef int (__stdcall * BINKSNDOFF) (struct BINKSND *BnkSnd, int status);
+typedef int (__stdcall * BINKSNDPAUSE) (struct BINKSND *BnkSnd, int status);
+typedef void (__stdcall * BINKSNDCLOSE) (struct BINKSND *BnkSnd);
+
+
+#define BINKFRAMERATE         0x00001000L
+#define BINKPRELOADALL        0x00002000L
+#define BINKSNDTRACK          0x00004000L
+#define BINKOLDFRAMEFORMAT    0x00008000L
+#define BINKRBINVERT          0x00010000L
+#define BINKGRAYSCALE         0x00020000L
+#define BINKNOMMX             0x00040000L
+#define BINKNOSKIP            0x00080000L
+#define BINKALPHA             0x00100000L
+#define BINKNOFILLIOBUF       0x00200000L
+#define BINKSIMULATE          0x00400000L
+#define BINKFILEHANDLE        0x00800000L
+#define BINKIOSIZE            0x01000000L
+#define BINKIOPROCESSOR       0x02000000L
+#define BINKFROMMEMORY        0x04000000L
+#define BINKNOTHREADEDIO      0x08000000L
+
+#define BINKSURFACEFAST       0x00000000L
+#define BINKSURFACESLOW       0x08000000L
+#define BINKSURFACEDIRECT     0x04000000L
+
+#define BINKCOPYALL           0x80000000L
+#define BINKCOPY2XH           0x10000000L
+#define BINKCOPY2XHI          0x20000000L
+#define BINKCOPY2XW           0x30000000L
+#define BINKCOPY2XWH          0x40000000L
+#define BINKCOPY2XWHI         0x50000000L
+#define BINKCOPY1XI           0x60000000L
+#define BINKCOPYNOSCALING     0x70000000L
+
+#define BINKSURFACE8P          0
+#define BINKSURFACE24          1
+#define BINKSURFACE24R         2
+#define BINKSURFACE32          3
+#define BINKSURFACE32R         4
+#define BINKSURFACE32A         5
+#define BINKSURFACE32RA        6
+#define BINKSURFACE4444        7
+#define BINKSURFACE5551        8
+#define BINKSURFACE555         9
+#define BINKSURFACE565        10
+#define BINKSURFACE655        11
+#define BINKSURFACE664        12
+#define BINKSURFACEYUY2       13
+#define BINKSURFACEUYVY       14
+#define BINKSURFACEYV12       15
+#define BINKSURFACEMASK       15
+
+#define BINKGOTOQUICK          1
+
+#define BINKGETKEYPREVIOUS     0
+#define BINKGETKEYNEXT         1
+#define BINKGETKEYCLOSEST      2
+#define BINKGETKEYNOTEQUAL   128
+
+
+//
+// The following will have been larger structs in the real Bink SDK headers, but are
+// only accessed through pointers so we don't care unless access to the internals
+// is required.
+//
+
+typedef struct BINKRECT
+{
+    int Left;
+    int Top;
+    int Width;
+    int Height;
+} BINKRECT;
+
+
+typedef struct BINKSND
+{
+    BINKSNDRESET SetParam;
+    BINKSNDRESET Reset;
+    BINKSNDREADY Ready;
+    BINKSNDLOCK Lock;
+    BINKSNDUNLOCK Unlock;
+    BINKSNDVOLUME Volume;
+    BINKSNDPAN Pan;
+    BINKSNDPAUSE Pause;
+    BINKSNDOFF Off;
+    BINKSNDCLOSE Close;
+    unsigned int BestSizeIn16;
+    unsigned int SoundDroppedOut;
+    unsigned int freq;
+    int bits;
+    int chans;
+    unsigned char snddata[128];
+} BINKSND;
+
+
+typedef struct BINKPLANE
+{
+    int Allocate;
+    void * Buffer;
+    unsigned int BufferPitch;
+} BINKPLANE;
+
+
+typedef struct BINKFRAMEPLANESET
+{
+  BINKPLANE YPlane;
+  BINKPLANE cRPlane;
+  BINKPLANE cBPlane;
+  BINKPLANE APlane;
+} BINKFRAMEPLANESET;
+
+
+typedef struct BINKFRAMEBUFFERS
+{
+    int TotalFrames;
+    unsigned int YABufferWidth;
+    unsigned int YABufferHeight;
+    unsigned int cRcBBufferWidth;
+    unsigned int cRcBBufferHeight;
+    unsigned int FrameNum;
+    BINKFRAMEPLANESET Frames[2];
+} BINKFRAMEBUFFERS;
+
+
+typedef struct BINK
+{
+    unsigned int Width;
+    unsigned int Height;
+    unsigned int Frames;
+    unsigned int FrameNum;
+    unsigned int LastFrameNum;
+    unsigned int FrameRate;
+    unsigned int FrameRateDiv;
+    unsigned int ReadError;
+    unsigned int OpenFlags;
+    unsigned int BinkType;
+    unsigned int Size;
+    unsigned int FrameSize;
+    unsigned int SndSize;
+    unsigned int FrameChangePercent;
+    BINKRECT FrameRects[8];
+    int NumRects;
+    BINKFRAMEBUFFERS *FrameBuffers;
+    void * MaskPlane;
+    unsigned int MaskPitch;
+    unsigned int MaskLength;
+    void * AsyncMaskPlane;
+    void * InUseMaskPlane;
+    void * LastMaskPlane;
+    unsigned int LargestFrameSize;
+    unsigned int InternalFrames;
+    int NumTracks;
+    unsigned int Highest1SecRate;
+    unsigned int Highest1SecFrame;
+    int Paused;
+} BINK;
+
+
+//
+// Use this define and don't call BinkOpenDirectSound directly!
+//
+#define BinkSoundUseDirectSound(lpDS) BinkSetSoundSystem(BinkOpenDirectSound, (unsigned int)lpDS)
+
+//
+// Function typedefs.
+//
+typedef int (__stdcall * BINKSETSOUNDSYSTEM)(BINKSNDSYSOPEN *open, unsigned int param);
+typedef void * (__stdcall * BINKOPENDIRECTSOUND)(unsigned int param);
+typedef char * (__stdcall * BINKGETERROR)(void);
+typedef HBINK (__stdcall * BINKOPEN)(const char *name, unsigned int flags);
+typedef void (__stdcall * BINKCLOSE)(HBINK bnk);
+typedef int (__stdcall * BINKDDSURFACETYPE)(void *lpDDS);
+typedef void (__stdcall * BINKGOTO)(HBINK bnk, unsigned int frame, unsigned int flags);  // use 1 for the first frame
+typedef int (__stdcall * BINKPAUSE)(HBINK bnk, int pause);
+typedef void (__stdcall *BINKNEXTFRAME)(HBINK bnk);
+typedef int (__stdcall * BINKCOPYTOBUFFER)(HBINK bnk, void *dest, int destpitch, unsigned int destheight, unsigned int destx, unsigned int desty, unsigned int flags);
+typedef int (__stdcall * BINKDOFRAME)(HBINK bnk);
+typedef int (__stdcall * BINKWAIT)(HBINK bnk);
+typedef int (__stdcall * BINKSETVOLUME)(HBINK bnk, int volume);
+typedef void (__stdcall BINKSETPAN)(HBINK bnk, int volume);
+
+
+#endif // _BINK_HEADER_H_

--- a/src/binkmovie/bink_load_dll.c
+++ b/src/binkmovie/bink_load_dll.c
@@ -1,0 +1,157 @@
+//
+// Utility functions for performing one-time loading of Bink library
+// functions from the DLL.
+//
+// The prototypes used assume you are using the version shipped
+// with Red Alert 2 or Renegade (roughly 1.0). If you have either of
+// these games installed you can copied it from there. We do not
+// distrubute or link to any version of the BinkSDK or DLL.
+//
+// Author: CCHyper
+//
+
+#include "TiberianSun.h"
+#include "bink_load_dll.h"
+
+
+BOOL BinkImportsLoaded = FALSE;
+
+static HMODULE BinkDLL = NULL;
+
+BINKCLOSE BinkClose = NULL;
+BINKDDSURFACETYPE BinkDDSurfaceType = NULL;
+BINKSETVOLUME BinkSetVolume = NULL;
+BINKGETERROR BinkGetError = NULL;
+BINKOPEN BinkOpen = NULL;
+BINKSETSOUNDSYSTEM BinkSetSoundSystem = NULL;
+BINKOPENDIRECTSOUND BinkOpenDirectSound = NULL;
+BINKGOTO BinkGoto = NULL;
+BINKPAUSE BinkPause = NULL;
+BINKNEXTFRAME BinkNextFrame = NULL;
+BINKCOPYTOBUFFER BinkCopyToBuffer = NULL;
+BINKDOFRAME BinkDoFrame = NULL;
+BINKWAIT BinkWait = NULL;
+
+
+BOOL __fastcall Load_Bink_DLL()
+{
+	// We already performed a sucessful one-time init, return TRUE.
+	if (BinkImportsLoaded) {
+		return TRUE;
+	}
+	
+	WWDebug_Printf("Load_Bink_DLL()\n");
+
+	// Look for Bink DLL.
+	if (BinkDLL == NULL && GetFileAttributesA("binkw32.dll") != INVALID_FILE_ATTRIBUTES) {
+		BinkDLL = LoadLibraryA("binkw32.dll");
+	}
+	
+	if (BinkDLL == NULL) {
+		WWDebug_Printf("LoadLibraryA() failed with %d.\n", GetLastError());
+		BinkImportsLoaded = FALSE;
+		return FALSE;
+	}
+
+	BinkClose = (BINKCLOSE)GetProcAddress(BinkDLL, "_BinkClose@4");
+	if (!BinkClose) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkClose", GetLastError());
+		return FALSE;
+	}
+
+	BinkDDSurfaceType = (BINKDDSURFACETYPE)GetProcAddress(BinkDLL, "_BinkDDSurfaceType@4");
+	if (!BinkDDSurfaceType) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkDDSurfaceType", GetLastError());
+		return FALSE;
+	}
+
+	BinkSetVolume = (BINKSETVOLUME)GetProcAddress(BinkDLL, "_BinkSetVolume@8");
+	if (!BinkSetVolume) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkSetVolume", GetLastError());
+		return FALSE;
+	}
+
+	BinkGetError = (BINKGETERROR)GetProcAddress(BinkDLL, "_BinkGetError@0");
+	if (!BinkGetError) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkGetError", GetLastError());
+		return FALSE;
+	}
+
+	BinkOpen = (BINKOPEN)GetProcAddress(BinkDLL, "_BinkOpen@8");
+	if (!BinkOpen) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "_BinkOpen@8", GetLastError());
+		return FALSE;
+	}
+
+	BinkSetSoundSystem = (BINKSETSOUNDSYSTEM)GetProcAddress(BinkDLL, "_BinkSetSoundSystem@8");
+	if (!BinkSetSoundSystem) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkSetSoundSystem", GetLastError());
+		return FALSE;
+	}
+
+	BinkOpenDirectSound = (BINKOPENDIRECTSOUND)GetProcAddress(BinkDLL, "_BinkOpenDirectSound@4");
+	if (!BinkOpenDirectSound) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkOpenDirectSound", GetLastError());
+		return FALSE;
+	}
+
+	BinkGoto = (BINKGOTO)GetProcAddress(BinkDLL, "_BinkGoto@12");
+	if (!BinkGoto) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkGoto", GetLastError());
+		return FALSE;
+	}
+
+	BinkPause = (BINKPAUSE)GetProcAddress(BinkDLL, "_BinkPause@8");
+	if (!BinkPause) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkPause", GetLastError());
+		return FALSE;
+	}
+
+	BinkNextFrame = (BINKNEXTFRAME)GetProcAddress(BinkDLL, "_BinkNextFrame@4");
+	if (!BinkNextFrame) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkNextFrame", GetLastError());
+		return FALSE;
+	}
+
+	BinkCopyToBuffer = (BINKCOPYTOBUFFER)GetProcAddress(BinkDLL, "_BinkCopyToBuffer@28");
+	if (!BinkCopyToBuffer) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkCopyToBuffer", GetLastError());
+		return FALSE;
+	}
+
+	BinkDoFrame = (BINKDOFRAME)GetProcAddress(BinkDLL, "_BinkDoFrame@4");
+	if (!BinkDoFrame) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkDoFrame", GetLastError());
+		return FALSE;
+	}
+
+	BinkWait = (BINKWAIT)GetProcAddress(BinkDLL, "_BinkWait@4");
+	if (!BinkWait) {
+		WWDebug_Printf("GetProcAddress failed to load %s (error: %d).\n", "BinkWait", GetLastError());
+		return FALSE;
+	}
+	
+	BinkImportsLoaded = TRUE;
+	return TRUE;
+}
+
+void __fastcall Unload_Bink_DLL()
+{
+	FreeLibrary(BinkDLL);
+	
+	BinkClose = NULL;
+	BinkDDSurfaceType = NULL;
+	BinkSetVolume = NULL;
+	BinkGetError = NULL;
+	BinkOpen = NULL;
+	BinkSetSoundSystem = NULL;
+	BinkOpenDirectSound = NULL;
+	BinkGoto = NULL;
+	BinkPause = NULL;
+	BinkNextFrame = NULL;
+	BinkCopyToBuffer = NULL;
+	BinkDoFrame = NULL;
+	BinkWait = NULL;
+	
+	BinkImportsLoaded = FALSE;
+}

--- a/src/binkmovie/bink_load_dll.h
+++ b/src/binkmovie/bink_load_dll.h
@@ -1,0 +1,39 @@
+//
+// Utility functions for performing one-time loading of Bink library
+// functions from the DLL.
+//
+// Author: CCHyper
+//
+
+#ifndef _BINK_LOAD_DLL_H_
+#define _BINK_LOAD_DLL_H_
+
+#include "bink.h"
+#include <Windows.h>
+
+
+extern BOOL BinkImportsLoaded;
+
+BOOL __fastcall Load_Bink_DLL();
+void __fastcall Unload_Bink_DLL();
+
+
+//
+// Pointers to Bink DLL exports.
+//
+extern BINKCLOSE BinkClose;
+extern BINKDDSURFACETYPE BinkDDSurfaceType;
+extern BINKSETVOLUME BinkSetVolume;
+extern BINKGETERROR BinkGetError;
+extern BINKOPEN BinkOpen;
+extern BINKSETSOUNDSYSTEM BinkSetSoundSystem;
+extern BINKOPENDIRECTSOUND BinkOpenDirectSound;
+extern BINKGOTO BinkGoto;
+extern BINKPAUSE BinkPause;
+extern BINKNEXTFRAME BinkNextFrame;
+extern BINKCOPYTOBUFFER BinkCopyToBuffer;
+extern BINKDOFRAME BinkDoFrame;
+extern BINKWAIT BinkWait;
+
+
+#endif // _BINK_LOAD_DLL_H_

--- a/src/binkmovie/bink_patches.c
+++ b/src/binkmovie/bink_patches.c
@@ -1,0 +1,170 @@
+//
+// Collection of patches that enable Bink movie support.
+//
+// Author: CCHyper
+//
+// NOTE: If you wish to make the Bink video playback interface
+//       exit on failure to play or find the the .BIK, the compile
+//       the project with "BINK_REQUIRED".
+//
+// WARNING: This playback interface assumes the user is playing at
+//          least 800x600, otherwise it will fail gracefully.
+//
+
+#include "macros/patch.h"
+#include "TiberianSun.h"
+#include <stdio.h>
+
+#include "bink_load_dll.h"
+#include "binkmovie.h"
+
+
+//
+// Play a bink movie.
+//
+BOOL __fastcall Play_Movie_As_Bink(char *filename, int theme, bool a3, bool stretch, bool hidden)
+{
+    WWKeyboardClass__Clear(WWKeyboard);
+    WWMouseClass__Hide_Mouse(WWMouse);
+	
+	// Load dll imports if not already loaded.
+	if (!BinkImportsLoaded) {
+		if (!Load_Bink_DLL()) {
+			WWDebug_Printf("Play_Movie_As_Bink failed to load DLL!\n", filename);
+#ifdef BINK_REQUIRED
+			ShowCursor(TRUE);
+			MessageBoxA(MainWindow, "Unable to load BinkW32.dll!\n", "Error!", MB_ICONWARNING|MB_OK);
+			Emergency_Exit();
+			exit(1);
+#endif
+			return FALSE;
+		}
+	}
+
+	// Only play fullscreen movies in campaign/singleplayer
+    if (SessionType.GameSession != GAME_CAMPAIGN) {
+        return FALSE;
+    }
+
+    if (hidden) {
+        HiddenSurface->vtable->Fill(HiddenSurface, 0);
+        GScreenClass__Do_Blit(1, HiddenSurface, 0);
+    }
+
+	// Prepare the bink movie player.
+	
+	if (!BinkMovie_Create(filename)) {
+		return FALSE;
+	}
+	
+    BinkBreakoutAllowed = TRUE;
+	
+	// Play!
+    BinkMovie_Play();
+
+    if (hidden) {
+        HiddenSurface->vtable->Fill(HiddenSurface, 0);
+        GScreenClass__Do_Blit(1, HiddenSurface, 0);
+    }
+	
+	// Cleanup bink movie the player.
+	BinkMovie_Close();
+
+    WWMouseClass__Show_Mouse(WWMouse);
+    GScreenClass__Flag_To_Redraw(&MouseClass_Map, 2);
+    WWKeyboardClass__Clear(WWKeyboard);
+	
+	return TRUE;
+}
+
+//
+// Intercept to the games Play_Movie which checks if the Bink video file is 
+// available, falling back to VQA if not.
+//
+void __fastcall Play_Movie_Intercept(char *filename, int theme, bool a3, bool stretch, bool hidden)
+{
+	static char filename_buffer[32];
+	strncpy(filename_buffer, filename, 32);
+	
+	// Find the location of the file extension indentifier.
+    char *movie_name = strchr((char *)filename_buffer, '.');
+	
+	// Unexpected filename format passed in.
+    if (!movie_name) {
+        WWDebug_Printf("Invalid movie filename \"%s\"!\n", filename_buffer);
+        return;
+    }
+
+	// Insert a null-char where the "." was. This will give us the actual
+	// movie name without the extension, allowing us to rebuild them.
+    *movie_name = '\0';
+
+    char *upper_filename = strupr((char *)filename_buffer);
+
+    char bink_buffer[32-4];
+    sprintf(bink_buffer, "%s.BIK", upper_filename);
+	
+    char vqa_buffer[32-4];
+    sprintf(vqa_buffer, "%s.VQA", upper_filename);
+	
+    CCFileClass binkfile;
+    CCFileClass vqafile;
+	
+	CCFileClass__CCFileClass(&binkfile, bink_buffer);
+	CCFileClass__CCFileClass(&vqafile, vqa_buffer);
+	
+	BOOL bink_available = CCFileClass__Is_Available(&binkfile, FALSE);
+	BOOL vqa_available = CCFileClass__Is_Available(&vqafile, FALSE);
+	
+	// If the movie exists as a .BIK, if so, play as Bink!
+	if (bink_available) {
+		WWDebug_Printf("Play_Movie \"%s\" as Bink!\n", upper_filename);
+		if (Play_Movie_As_Bink(bink_buffer, theme, a3, stretch, hidden)) {
+			CCFileClass__Destroy(&binkfile);
+			CCFileClass__Destroy(&vqafile);
+			return;
+		}
+	}
+		
+	// The movie did not exist as a .BIK or failed to play, attempt to play the .VQA.
+    if (vqa_available) {
+        WWDebug_Printf("Play_Movie \"%s\" as VQA!\n", upper_filename);
+        Play_Movie(vqa_buffer, theme, a3, stretch, hidden);	// Call the game Play_Movie.
+		
+    } else {
+		WWDebug_Printf("Failed to play movie \"%s\"!\n", upper_filename);
+	}
+		
+	CCFileClass__Destroy(&binkfile);
+	CCFileClass__Destroy(&vqafile);
+}
+
+
+void Bink_Library_Shutdown()
+{
+	// Cleanup dll imports.
+	if (BinkImportsLoaded) {
+		Unload_Bink_DLL();
+	}
+}
+
+
+//
+// Hook in our intercepts.
+//
+CALL(0x004E07AD, _Play_Movie_Intercept);
+CALL(0x004E07CC, _Play_Movie_Intercept);
+CALL(0x004E0840, _Play_Movie_Intercept);
+CALL(0x004E2865, _Play_Movie_Intercept);
+CALL(0x004E287F, _Play_Movie_Intercept);
+CALL(0x00563A1C, _Play_Movie_Intercept);
+CALL(0x0057FEDA, _Play_Movie_Intercept);
+CALL(0x0057FF3F, _Play_Movie_Intercept);
+CALL(0x005DB314, _Play_Movie_Intercept);
+CALL(0x005E35C8, _Play_Movie_Intercept);
+
+//CLEAR(0x00602467, 0x90, 0x00602474);
+CALL(0x00602474, _Bink_Library_Shutdown);
+SETBYTE(0x00602479, 0x5E); // pop esi
+SETBYTE(0x0060247A, 0x5B); // pop ebx
+SETBYTE(0x0060247B, 0xC3); // ret

--- a/src/binkmovie/binkmovie.c
+++ b/src/binkmovie/binkmovie.c
@@ -1,0 +1,479 @@
+//
+// Bink video player interface that uses the games drawer.
+//
+// Due to the use of the older version of the Bink32.dll, make sure
+// any .BIK video you produce sets the "Compress level" to the desired
+// compression level +100. Example; A level of 4 should be 104, this makes
+// the encoder produce the BIK video file with the older audio format
+// which is required by the older DLL. Otherwise you will not hear any
+// audio when you video is played back by the game.
+//
+// Author: CCHyper
+//
+
+#include "binkmovie.h"
+#include "bink.h"
+#include "bink_load_dll.h"
+#include <assert.h>
+
+
+BOOL BinkBreakoutAllowed = TRUE;
+BOOL BinkScaleToFit = FALSE;
+
+
+// Master playback volume.
+static float BinkMasterVolume = 0.7f;
+
+static HBINK BinkHandle;
+static int SurfaceFlags;
+static DSurface * BinkVideoSurface;
+static RECT VideoRect;
+static HANDLE FileHandle;
+static BOOL IsPlaying;
+static BOOL NewFrame;
+static int LastFrameNum;
+
+
+BOOL Audio_Available()
+{
+	return !Debug_Quiet && DSAudio_SoundObject && !DSAudio_AudioDone;
+}
+
+
+LPDIRECTSOUND Audio_SoundObject()
+{
+	return DSAudio_SoundObject;
+}
+
+
+void __fastcall BinkMovie_Close(void)
+{
+    if (BinkHandle) {
+        BinkClose(BinkHandle);
+		BinkHandle = 0;
+    }
+    if (FileHandle != INVALID_HANDLE_VALUE) {
+        CloseHandle(FileHandle);
+        FileHandle = INVALID_HANDLE_VALUE;
+    }
+	
+    BinkVideoSurface = NULL;
+}
+
+
+void __fastcall BinkMovie_SetPosition(unsigned x_pos, unsigned y_pos)
+{
+    WWDebug_Printf("BinkMovie_SetPosition()\n");
+
+    RECT surface_rect;
+	surface_rect.left = 0;
+	surface_rect.top = 0;
+	surface_rect.right = BinkVideoSurface->Width;
+    surface_rect.bottom = BinkVideoSurface->Height;
+
+    RECT bink_rect;
+	bink_rect.left = x_pos;
+	bink_rect.top = y_pos;
+	bink_rect.right = BinkHandle->Width;
+	bink_rect.bottom = BinkHandle->Height;
+
+    VideoRect = Rect_Intersect(&surface_rect, &bink_rect, NULL, NULL);
+}
+
+
+void __fastcall BinkMovie_Go_To_Frame(int frame)
+{
+    BinkGoto(BinkHandle, frame, BINKGOTOQUICK);
+    LastFrameNum = 0;
+}
+
+
+void __fastcall BinkMovie_Pause(BOOL pause)
+{
+    BinkPause(BinkHandle, (pause & 0xFF));
+}
+
+
+BOOL __fastcall BinkMovie_Has_Frames_Left(void)
+{
+    return BinkHandle->FrameNum >= BinkHandle->Frames || BinkHandle->FrameNum < LastFrameNum;
+}
+
+
+BOOL __fastcall BinkMovie_Open(char * filename)
+{
+    BinkMovie_Close();
+
+    LastFrameNum = 0;
+
+    //
+    // Tell Bink to use DirectSound (must be before BinkOpen)!
+    //
+    if (Audio_Available()) {
+        BinkSoundUseDirectSound((BINKOPENDIRECTSOUND)Audio_SoundObject());
+    } else {
+		WWDebug_Printf("BinkMovie_Open() - Audio playback not available.\n");
+	}
+    
+    //
+    // Open a handle to the file if it exists locally.
+    //
+	RawFileClass file;
+	RawFileClass__RawFileClass(&file, filename);
+    if (RawFileClass__Is_Available(&file, FALSE)) {
+        BinkHandle = BinkOpen(filename, 0);
+
+    } else {
+        
+        //
+        // So the file was not found locally, try finding it within a mixfile.
+        //
+        long start = 0;
+        MixFileClass *mixfile = NULL;
+        if (MixFileClass__Offset(filename, NULL, &mixfile, &start, NULL)) {
+
+            FileHandle = CreateFileA(mixfile->Filename, GENERIC_READ, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            if (FileHandle != INVALID_HANDLE_VALUE) {
+                
+                //
+                // Set the file handle pointer to the offset within the mixfile.
+                //
+                SetFilePointer(FileHandle, start, NULL, FILE_BEGIN);
+
+                //
+                // Now open the handle. When we pass "BINKFILEHANDLE" into BinkOpen, it tells the
+                // Bink playback engine that the first param is in fact a Windows file handle and
+                // not the actual filename.
+                //
+                BinkHandle = BinkOpen((char *)FileHandle, BINKFILEHANDLE);
+            }
+        }
+    }
+	
+	if (BinkHandle->Width > GameOptionsClass_ScreenWidth || BinkHandle->Height > GameOptionsClass_ScreenHeight) {
+		WWDebug_Printf("Video can not be played due to low user resolution!\n");
+		ShowCursor(TRUE);
+		char buffer[256];
+		sprintf(buffer,
+			"Video \"%s\" can not be played due to low resolution size, please\n"
+			"increase your resolution to at least %dx%d to play this video.\n",
+			filename, BinkHandle->Width, BinkHandle->Height);
+		MessageBoxA(MainWindow, buffer, "Error!", MB_ICONWARNING|MB_OK);
+		BinkMovie_Close();
+#ifdef BINK_REQUIRED
+		Emergency_Exit();
+		exit(1);
+#else
+		ShowCursor(FALSE);
+#endif
+		return FALSE;
+	}
+
+    if (BinkHandle) {
+
+        //
+        // Adjust playback volume based on the set user volume.
+        //
+        if (GameOptionsClass_VoiceVolume != BinkMasterVolume) {
+            BinkMasterVolume = GameOptionsClass_VoiceVolume;
+            BinkSetVolume(BinkHandle, (BinkMasterVolume * 32768.0f));
+        }
+
+        RECT rect;
+        int x = 0;
+        int y = 0;
+
+        if (!BinkVideoSurface) {
+			BinkVideoSurface = PrimarySurface;
+		}
+		
+		//
+		// Center video in the main window.
+		//
+		GetClientRect(MainWindow, &rect);
+		x = (rect.right - rect.left - BinkHandle->Width) / 2;
+		y = (rect.bottom - rect.top - BinkHandle->Height) / 2;
+
+        BinkMovie_SetPosition(x, y);
+
+        //
+        // Store a copy of the surface flags.
+        //
+        SurfaceFlags = BinkDDSurfaceType((void *)PrimarySurface->VideoSurfacePtr);
+
+        return TRUE;
+    }
+
+    WWDebug_Printf("BinkMovie_Open() - Bink Error: %s\n", BinkGetError());
+
+    return FALSE;
+}
+
+
+BOOL __fastcall BinkMovie_Next_Frame(DSurface * surface, unsigned x_pos, unsigned y_pos)
+{
+    if (GameOptionsClass_VoiceVolume != BinkMasterVolume) {
+        BinkMasterVolume = GameOptionsClass_VoiceVolume;
+        BinkSetVolume(BinkHandle, (BinkMasterVolume * 32768.0f));
+    }
+
+    BinkMovie_ResumePause();
+
+    int result = BinkWait(BinkHandle);
+
+    //
+    // Do we have a new frame to draw?
+    //
+    if (NewFrame || !result) {
+
+        //
+        // Check to see if a frame is ready to be drawn.
+        //
+        while (!BinkWait(BinkHandle)) {
+
+            //
+            // Start decompressing the next frame.
+            //
+            BinkDoFrame(BinkHandle);
+
+            NewFrame = FALSE;
+
+            BinkMovie_Render_Frame(surface, x_pos, y_pos);
+
+            LastFrameNum = BinkHandle->FrameNum;
+
+            //
+            // Next frame, please.
+            //
+            BinkNextFrame(BinkHandle);
+        }
+
+        return TRUE;
+    }
+
+    return result;
+}
+
+
+BOOL __fastcall BinkMovie_Advance_Frame(void)
+{
+    return BinkMovie_Next_Frame(BinkVideoSurface, VideoRect.left, VideoRect.top);
+}
+
+
+void __fastcall BinkMovie_Play(void)
+{
+    if (!BinkHandle) {
+        WWDebug_Printf("BinkMovie_Play() - Bink handle is null! Bink Error: %s\n", BinkGetError());
+        return;
+    }
+
+    WWKeyboardClass__Clear(WWKeyboard);
+
+    IsPlaying = TRUE;
+    NewFrame = FALSE;
+
+    for (;;) {
+    
+        if (BinkMovie_Has_Frames_Left()) {
+            break;
+        }
+
+        //
+        // Are there any messages to handle?
+        //
+        if (!VQA_Windows_Message_Loop()) {
+            break;
+
+        } else {
+
+            //
+            // If paused, we don't need to redraw every tick, so add a little wait to take
+            // the stress away from the CPU, because you know, it has a hard life...
+            //
+            if (!IsPlaying) {
+                Sleep(33); // Sleep for 33 msec.
+            }
+
+            //
+            // Draw the next frame.
+            //
+            if (BinkVideoSurface == PrimarySurface) {
+
+                RECT rect;
+                GetClientRect(MainWindow, &rect);
+                ClientToScreen(MainWindow, (LPPOINT)&rect);
+
+                BinkMovie_Next_Frame(BinkVideoSurface, rect.left + VideoRect.left, rect.top + VideoRect.top);
+
+            } else if (BinkMovie_Next_Frame(BinkVideoSurface, VideoRect.left, VideoRect.top)) {
+
+                RECT rect;
+                GetClientRect(MainWindow, &rect);
+                ClientToScreen(MainWindow, (LPPOINT)&rect);
+
+                RECT dest_rect = VideoRect;
+                dest_rect.left += rect.left;
+                dest_rect.top += rect.top;
+                PrimarySurface->vtable->BlitPart(PrimarySurface, &dest_rect, BinkVideoSurface, &VideoRect, false, true);
+            }
+
+            //
+            // Check if the Esc key has been pressed. If so, break out and stop all
+            // frame updates.
+            //
+			if (BinkBreakoutAllowed) {
+				if (WWKeyboardClass__Check(WWKeyboard) && WWKeyboardClass__Get(WWKeyboard) == (KN_RLSE_BIT|KN_ESC)) {
+					WWDebug_Printf("BinkMovie_Callback() - Breakout.\n");
+					break;
+				}
+			}
+
+        }
+    
+    }
+
+    WWKeyboardClass__Clear(WWKeyboard);
+}
+
+
+void __fastcall BinkMovie_Draw_Frame(void)
+{
+    if (BinkVideoSurface == PrimarySurface) {
+        RECT rect;
+        GetClientRect(MainWindow, &rect);
+        ClientToScreen(MainWindow, (LPPOINT)&rect);
+        BinkMovie_Render_Frame(BinkVideoSurface, rect.left + VideoRect.left, rect.top + VideoRect.top);
+    } else {
+        BinkMovie_Render_Frame(BinkVideoSurface, VideoRect.left, VideoRect.top);
+    }
+}
+
+
+void __fastcall BinkMovie_Render_Frame(DSurface * surface, unsigned x_pos, unsigned y_pos)
+{
+    if (!surface) {
+        WWDebug_Printf("BinkMovie_Render_Frame() - Surface is null!\n");
+        return;
+    }
+
+    //
+    // Lock the surface so that we can copy the decompressed frame into it.
+    //
+    void *buffptr = surface->vtable->Lock(surface, 0, 0);
+    if (buffptr) {
+		
+		if (BinkScaleToFit) {
+			
+			//
+			// Copy the decompressed frame into the buffer surface, then scale copy to the primary surface.
+			//
+			
+			// TODO!
+			
+			//BSurface buffsurface(BinkHandle->Width, BinkHandle-Height, surface->vtable->Get_Pitch(surface));
+			//BinkCopyToBuffer(BinkHandle, buffptr, buffsurface.vtable->Get_Pitch(surface), buffsurface->Height, x_pos, y_pos, SurfaceFlags|BINKCOPYALL);
+			
+			//PrimarySurface->vtable->BlitPart(buffsurface);
+			
+		} else {
+			
+			//
+			// Copy the decompressed frame into the surface buffer (this might be currently on-screen).
+			//
+			BinkCopyToBuffer(BinkHandle, buffptr, surface->vtable->Get_Pitch(surface), surface->Height, x_pos, y_pos, SurfaceFlags|BINKCOPYALL);
+			
+		}
+
+        //
+        // Finished, now unlock the BinkBuffer.
+        //
+        surface->vtable->Unlock(surface);
+    }
+}
+
+
+BOOL __fastcall BinkMovie_Create(char * filename)
+{
+	if (!BinkImportsLoaded) {
+		return FALSE;
+	}	
+	
+    BinkHandle = 0;
+    SurfaceFlags = 0;
+    BinkVideoSurface = NULL;
+    BinkVideoSurface = PrimarySurface;
+    VideoRect.left = 0;
+    VideoRect.top = 0;
+    VideoRect.right = 0;
+    VideoRect.bottom = 0;
+    FileHandle = INVALID_HANDLE_VALUE;
+    IsPlaying = TRUE;
+    NewFrame = FALSE;
+    LastFrameNum = 0;
+
+    return BinkMovie_Open(filename);
+}
+
+
+BOOL __fastcall BinkMovie_CreateSurface(char * filename, DSurface *surface)
+{
+	if (!BinkImportsLoaded) {
+		return FALSE;
+	}
+	
+    BinkHandle = 0;
+    SurfaceFlags = 0;
+    BinkVideoSurface = NULL;
+    BinkVideoSurface = surface;
+    VideoRect.left = 0;
+    VideoRect.top = 0;
+    VideoRect.right = 0;
+    VideoRect.bottom = 0;
+    FileHandle = INVALID_HANDLE_VALUE;
+    IsPlaying = TRUE;
+    NewFrame = FALSE;
+    LastFrameNum = 0;
+
+    return BinkMovie_Open(filename);
+}
+
+
+void __fastcall BinkMovie_Destroy(void)
+{
+	if (!BinkImportsLoaded) {
+		return;
+	}
+	
+    BinkMovie_Close();
+}
+
+
+BOOL __fastcall BinkMovie_ResumePause(void)
+{
+    BOOL playing = IsPlaying;
+
+    if (GameInFocus) {
+        if (!playing) {
+            WWDebug_Printf("BinkMovie_ResumePause() - Resume bink movie.\n");
+            IsPlaying = TRUE;
+            BinkMovie_Pause(FALSE);
+            BinkMovie_Draw_Frame();
+        }
+
+    } else if (playing) {
+        WWDebug_Printf("BinkMovie_ResumePause() - Pause bink movie.\n");
+        IsPlaying = FALSE;
+        BinkMovie_Pause(TRUE);
+    }
+
+    return playing;
+}
+
+
+float __fastcall BinkMovie_Set_Master_Volume(float vol)
+{
+    float old = BinkMasterVolume;
+    BinkMasterVolume = vol;
+    return old;
+}

--- a/src/binkmovie/binkmovie.h
+++ b/src/binkmovie/binkmovie.h
@@ -1,0 +1,39 @@
+//
+// Bink video player interface that uses the games drawer.
+//
+// Author: CCHyper
+//
+ 
+#ifndef _BINK_MOVIE_H_
+#define _BINK_MOVIE_H_
+
+#include "TiberianSun.h"
+#include <Windows.h>
+
+
+BOOL __fastcall BinkMovie_Create(char * filename);
+BOOL __fastcall BinkMovie_CreateSurface(char * filename, DSurface *surface);
+void __fastcall BinkMovie_Play(void);
+void __fastcall BinkMovie_Close(void);
+void __fastcall BinkMovie_SetPosition(unsigned x_pos, unsigned y_pos);
+void __fastcall BinkMovie_Go_To_Frame(int frame);
+void __fastcall BinkMovie_Pause(BOOL pause);
+BOOL __fastcall BinkMovie_Has_Frames_Left(void);
+BOOL __fastcall BinkMovie_Open(char * filename);
+BOOL __fastcall BinkMovie_Next_Frame(DSurface * surface, unsigned x_pos, unsigned y_pos);
+BOOL __fastcall BinkMovie_Advance_Frame(void);
+void __fastcall BinkMovie_Draw_Frame(void);
+void __fastcall BinkMovie_Render_Frame(DSurface * surface, unsigned x_pos, unsigned y_pos);
+void __fastcall BinkMovie_Destroy(void);
+BOOL __fastcall BinkMovie_ResumePause(void);
+float __fastcall BinkMovie_Set_Master_Volume(float vol);
+
+
+//
+// Flag to start playing?
+//
+extern BOOL BinkBreakoutAllowed;
+extern BOOL BinkScaleToFit;
+
+
+#endif // _BINK_MOVIE_H_

--- a/sym.asm
+++ b/sym.asm
@@ -108,7 +108,10 @@ setcglob 0x00449850, CCFileClass__Write
 setcglob 0x00449A40, CCFileClass__Open
 setcglob 0x004499C0, CCFileClass__Is_Available
 setcglob 0x00449970, CCFileClass__Size
+setcglob 0x005BE310, RawFileClass__RawFileClass
+setcglob 0x005BE470, RawFileClass__Is_Available
 setcglob 0x005BE9C0, RawFileClass__Create
+setcglob 0x005BE290, RawFileClass__Destroy
 
 ; Session
 setcglob 0x007E2458, SessionClass_this
@@ -201,6 +204,9 @@ setcglob 0x007E3EA0, NameNodes_CurrentSize
 setcglob 0x007E2508, HumanPlayers
 setcglob 0x007E3EA0, HumanNode_ActiveCount
 setcglob 0x007E4720, GameOptionsClass_GameSpeed
+setcglob 0x007E474C, GameOptionsClass_VoiceVolume
+setcglob 0x007E473C, GameOptionsClass_ScreenWidth
+setcglob 0x007E4740, GameOptionsClass_ScreenHeight
 
 ; Scenario
 setcglob 0x007E28B8, ScenarioName
@@ -223,9 +229,15 @@ setcglob 0x005D6910, Load_Game
 setcglob 0x0074C8F0, WWMouseClas_Mouse
 setcglob 0x00748348, MouseClass_Map
 setcglob 0x007482C0, WWKeyboard
+setcglob 0x0074C8F0, WWMouse
 setcglob 0x007E47B0, Left_Shift_Key
 setcglob 0x007E47B4, Right_Shift_Key
 setcglob 0x004FB390, WWKeyboardClass__Down
+setcglob 0x004FB4F0, WWKeyboardClass__Clear
+setcglob 0x004FAF30, WWKeyboardClass__Check
+setcglob 0x004FAF80, WWKeyboardClass__Get
+setcglob 0x006A5FE0, WWMouseClass__Show_Mouse
+setcglob 0x006A6140, WWMouseClass__Hide_Mouse
 setcglob 0x0059C9D0, PrettyPrintKey
 setcglob 0x007E47A8, ForceFire1
 setcglob 0x007E47AC, ForceFire2
@@ -244,6 +256,7 @@ setcglob 0x0052BBE0, MapClass__Fill_Map_With_Fog
 setcglob 0x007B3304, dword_7B3304
 setcglob 0x004B9470, GScreenClass__Input
 setcglob 0x004B95A0, GScreenClass__Render
+setcglob 0x004B96C0, GScreenClass__Do_Blit
 setcglob 0x0061CBA0, TActionClass__Zoom_Out
 setcglob 0x0061CB30, TActionClass__Zoom_In
 setcglob 0x004B9440, GScreenClass__Flag_To_Redraw
@@ -287,6 +300,8 @@ setcglob 0x00865040, hWndParent
 setcglob 0x00474E70, Fancy_Text_Print
 setcglob 0x00474A50, Simple_Text_Print
 setcglob 0x00685BC0, WndProc
+setcglob 0x00865040, MainWindow
+setcglob 0x007E4920, GameInFocus
 
 ; Sidebar
 setcglob 0x0080C3BC, SidebarClass_Redraw_Buttons
@@ -299,6 +314,13 @@ setcglob 0x005F3560, SidebarClass__Draw_It
 setcglob 0x005F2720, SidebarClass__Init_IO
 setcglob 0x005F2900, SidebarClass__Init_For_House
 
+; Audio
+setcglob 0x007A27CC, DSAudio_SoundObject
+setcglob 0x007A27DC, DSAudio_AudioDone
+
+; Debug
+setcglob 0x007E4903, Debug_Quiet
+
 ; clib
 setcglob 0x006B73A0, __strcmpi
 setcglob 0x006B8E20, strcmp
@@ -310,9 +332,12 @@ setcglob 0x006B6A41, vsprintf
 setcglob 0x006B69C1, fprintf
 setcglob 0x006BC70C, fwrite
 
+setcglob 0x006B6AB0, strchr
+setcglob 0x006C6A96, strupr
 setcglob 0x006B6730, stristr_
 setcglob 0x006BA490, strlen
 setcglob 0x006BE630, strcpy
+setcglob 0x006B51F0, strncpy
 setcglob 0x006B6BA0, strncat
 setcglob 0x006BE766, strdup
 setcglob 0x006B6730, strstr
@@ -369,12 +394,19 @@ setcglob 0x004E90D0, CenterTeamCommandClass_Execute
 setcglob 0x004EAB00, ScreenCaptureCommandClass_Execute
 setcglob 0x005B10F0, Queue_Options
 
+setcglob 0x00413760, Rect_Intersect
+
+setcglob 0x00602480, Emergency_Exit
+setcglob 0x006B6EAA, exit
+
 ;WSOCK32
 setcglob 0x006CA504, _imp__sendto
 setcglob 0x006CA4FC, _imp__recvfrom
 
 setcglob 0x006CA24C, _imp__GetCommandLineA
 setcglob 0x006CA16C, _imp__LoadLibraryA
+setcglob 0x006CA1F8, _imp__FreeLibrary
+setcglob 0x006CA2A4, _imp__GetFileAttributesA
 setcglob 0x006CA174, _imp__GetProcAddress
 setcglob 0x006CA1D0, _imp__GetCurrentProcess
 setcglob 0x006CA4EC, _imp__timeGetTime
@@ -391,6 +423,8 @@ setcglob 0x006CA448, _imp__GetKeyNameTextA
 setcglob 0x006CA398, _imp__MapVirtualKeyA
 setcglob 0x006CA394, _imp__ToAscii
 setcglob 0x006CA3BC, SetWindowPos
+setcglob 0x006CA388, _imp__GetClientRect
+setcglob 0x006CA384, _imp__ClientToScreen
 setcglob 0x006CA360, _imp__SetFocus
 setcglob 0x006CA360, SetFocus
 setcglob 0x006CA3C8, InvalidateRect
@@ -409,7 +443,8 @@ setcglob 0x006CA1E8, _imp__WaitForSingleObject
 setcglob 0x006CA1F0, _imp__ReleaseMutex
 setcglob 0x006CA144, _imp__ResetEvent
 setcglob 0x006Ca15C, _imp__SetEvent
-
+setcglob 0x006CA194, _imp__GetLastError
+setcglob 0x006CA458, _imp__MessageBoxA
 
 ; Theme
 setcglob 0x00644190, Theme__Stop
@@ -435,6 +470,7 @@ setcglob 0x004EAF20, Delete_Waypoint
 
 setcglob 0x0047C780, CC_Draw_Shape
 setcglob 0x00559DE0, MixFileClass__CCFileClass__Retrieve
+setcglob 0x0055A1C0, MixFileClass__Offset
 setcglob 0x0074C5D8, PrimarySurface
 setcglob 0x0074C5D0, SidebarSurface
 setcglob 0x0074C5E4, TempSurface
@@ -444,6 +480,9 @@ setcglob 0x0074C5DC, HiddenSurface
 setcglob 0x0048BB00, DSurface_FillRect
 setcglob 0x0048C140, DSurface_Conversion_Type
 setcglob 0x0069FAE0, Write_PCX_File
+
+setcglob 0x00563670, Play_Movie
+setcglob 0x0066B230, VQA_Windows_Message_Loop
 
 
 ;Address  Ordinal Name                          Library

--- a/sym.asm
+++ b/sym.asm
@@ -445,6 +445,8 @@ setcglob 0x006CA144, _imp__ResetEvent
 setcglob 0x006Ca15C, _imp__SetEvent
 setcglob 0x006CA194, _imp__GetLastError
 setcglob 0x006CA458, _imp__MessageBoxA
+setcglob 0x006CA36C, ShowCursor
+setcglob 0x006CA36C, _imp__ShowCursor
 
 ; Theme
 setcglob 0x00644190, Theme__Stop


### PR DESCRIPTION
This PR adds support for Bink video (version 1) to Tiberian Sun. _Sidebar video support is not implemented in this PR._

This system is optional, three conditions must be met for the game to play a Bink video;
- The .BIK video must exist (for example, WWLOGO.BIK).
- The user's resolution must be at least 800x600.
- The Bink library is found, BINKW32.DLL.

It is suggested you create videos at a resolution of no larger than 800x600. The game will attempt to show an error message when the video is larger than the users resolution, but may also crash. Please keep this in mind. 

The implementation is based on the same version that Red Alert 2 uses, thus only works with Bink V1.0~.

**Some additional notes:**
Due to the use of the older version of the BINKW32.DLL, please make sure any .BIK video you produce sets the "Compress level" to the desired compression level +100. For example; A level of 4 should be 104, this makes the encoder produce the BIK video file with the older audio format which is required by the older DLL. Otherwise, you will not hear any audio when your video is played back by the game. See attached screenshot for the best options to use when creating the Bink video.

Also, an optional compile option can be used if you wish to make the Bink video playback interface exit on failure to play or find the .BIK, just compile the project with **BINK_REQUIRED**.

Optional settings for creating .BIK;
<img width="532" alt="Untitled" src="https://user-images.githubusercontent.com/73803386/113942922-98bb6180-97f9-11eb-908c-0e82b8e2068e.png">