### PR TITLE
Implements Bink sidebar video support and fullscreen scaling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ COMMON_OBJS = \
               src/video_mode_hacks.o \
               src/binkmovie/bink_load_dll.o \
               src/binkmovie/bink_patches.o \
+              src/binkmovie/bink_asm_patches.o \
               src/binkmovie/binkmovie.o \
               res/res.o \
               sym.o

--- a/inc/Classes/DSurface.h
+++ b/inc/Classes/DSurface.h
@@ -59,4 +59,16 @@ typedef struct DSurface {
 	LPDDSURFACEDESC VideoSurfaceDescription; // Description of the said surface.
 } DSurface;
 
+
+typedef struct BSurface {
+    vtDSurface *vtable;
+    int32_t Width;
+    int32_t Height;
+    int32_t LockLevel;
+    int32_t BitsPerPixel;
+	void *BufferPtr;
+	int32_t BufferSize;
+	char IsAllocated;
+} BSurface;
+
 extern DSurface *PrimarySurface;

--- a/inc/TiberianSun.h
+++ b/inc/TiberianSun.h
@@ -71,6 +71,9 @@ extern CommandClass ToggleInfoPanelCommand;
 extern CommandClass PlaceBuildingCommand;
 extern CommandClass RepeatBuildingCommand;
 extern CommandClass SelectOneLessCommand;
+extern DynamicVectorClass DynamicVectorClass_Movies;
+extern char ** DynamicVectorClass_Movies_Vector;
+extern int DynamicVectorClass_Movies_ActiveCount;
 
 extern bool SpawnerActive;
 extern bool Player_Active;
@@ -142,12 +145,20 @@ extern int GameOptionsClass_GameSpeed;
 extern int GameOptionsClass_VoiceVolume;
 extern int GameOptionsClass_ScreenWidth;
 extern int GameOptionsClass_ScreenHeight;
+extern bool GameOptionsClass_StretchMovies;
 extern int RequestedFPS;
 extern int NormalizedDelayGameSpeed;
 extern int ScenarioInit;
 extern int GameInFocus;
 extern HWND MainWindow;
 extern bool Debug_Quiet;
+extern bool Radar_Movie_Playing;
+extern int IngameVQ_Count;
+extern int DSAudio;
+extern void *Current_Movie_Ptr;
+extern int RadarClass_14B4;
+extern int RadarClass_14BC;
+extern bool InScenario;
 
 // ### Functions ###
 void Queue_Options();
@@ -218,8 +229,15 @@ void __thiscall SidebarClass__Draw_It(MouseClass *Map, char a2);
 void __thiscall SidebarClass__Init_IO(MouseClass *this);
 void __thiscall SidebarClass__Init_For_House(MouseClass *this);
 void __thiscall DisplayClass__Init_IO(void *this);
+void __thiscall RadarClass__Play_Movie(MouseClass *this);
+void __thiscall RadarClass__Radar_Activate(MouseClass *this, int a2);
 
 void __fastcall Play_Movie(char *filename, int theme, bool a3, bool a4, bool a5);
+void __fastcall Play_Ingame_Movie(int vqtype);
+
+void __thiscall DSAudio_Set_Volume_All(int this, int vol);
+int __thiscall DSAudio_Set_Volume_Percent(int this, int percent);
+bool __fastcall Is_Speaking(void);
 
 void __fastcall Emergency_Exit();
 void __cdecl exit(int code);
@@ -299,6 +317,9 @@ bool __fastcall MixFileClass__Offset(const char * filename, void ** realptr, Mix
 
 bool __fastcall VQA_Windows_Message_Loop(void);
 
+void __fastcall MovieClass_Update(void);
+void __fastcall Movie_Handle_Focus(bool state);
+
 void __thiscall Print_CRCs(int a1);
 
 RECT __fastcall Rect_Intersect(RECT *rect1, RECT *rect2, int *x, int *y);
@@ -317,6 +338,8 @@ int32_t _sprintf(char *dest, char *format, ...);
 size_t __strcmpi(const char *, const char *);
 char *__cdecl strncpy(char *Dest, const char *Source, size_t Count);
 
+
+extern const int vtBSurface;
 
 // ### Variables ###
 

--- a/src/binkmovie/bink_asm_patches.asm
+++ b/src/binkmovie/bink_asm_patches.asm
@@ -1,0 +1,45 @@
+;
+; Collection of ASM patches that enable Bink movie support.
+;
+; Author: CCHyper
+;
+%include "TiberianSun.inc"
+%include "macros/patch.inc"
+
+cextern Windows_Procedure_Should_Blit_Patch
+cextern CompositeSurface
+cextern WWMouse
+cextern InScenario
+cextern BinkFullscreenMovie
+cextern Current_Movie_Ptr
+cextern IngameVQ_Count
+
+@LJMP 0x00685CB9, _Windows_Procedure_Should_Blit_Patch_asm_patch
+
+;
+; This fixes a issue were the game be seen behind the video
+; if the window moves. This was a bug in the vanilla game.
+;
+_Windows_Procedure_Should_Blit_Patch_asm_patch:
+	cmp byte [InScenario], 1
+	jnz .move_update
+
+	mov edx, dword [BinkFullscreenMovie]
+	test edx, edx
+	jnz .move_update
+
+	mov edx, dword [Current_Movie_Ptr]
+	test edx, edx
+	jnz .move_update
+
+	mov edx, dword [IngameVQ_Count]
+	cmp edx, 1
+	jge .move_update
+	
+	; Blit game layer.
+	mov eax, dword [CompositeSurface]
+	jmp 0x00685CC2
+	
+	; Update a movie
+.move_update:
+	jmp 0x00685CEE

--- a/src/binkmovie/bink_patches.c
+++ b/src/binkmovie/bink_patches.c
@@ -57,6 +57,8 @@ BOOL __fastcall Play_Movie_As_Bink(char *filename, int theme, bool a3, bool stre
 		return FALSE;
 	}
 	
+	BinkFullscreenMovie = TRUE;
+	
     BinkBreakoutAllowed = TRUE;
 	
 	// Play!
@@ -69,6 +71,8 @@ BOOL __fastcall Play_Movie_As_Bink(char *filename, int theme, bool a3, bool stre
 	
 	// Cleanup bink movie the player.
 	BinkMovie_Close();
+	
+	BinkFullscreenMovie = FALSE;
 
     WWMouseClass__Show_Mouse(WWMouse);
     GScreenClass__Flag_To_Redraw(&MouseClass_Map, 2);
@@ -140,6 +144,248 @@ void __fastcall Play_Movie_Intercept(char *filename, int theme, bool a3, bool st
 }
 
 
+//
+// Play a ingame bink movie.
+//
+BOOL __fastcall Play_Ingame_Movie_As_Bink(char *filename)
+{
+	// Load dll imports if not already loaded.
+	if (!BinkImportsLoaded) {
+		if (!Load_Bink_DLL()) {
+			WWDebug_Printf("Play_Ingame_Movie_As_Bink failed to load DLL!\n", filename);
+#ifdef BINK_REQUIRED
+			MessageBoxA(MainWindow, "Unable to load BinkW32.dll!\n", "Error!", MB_OK);
+			Emergency_Exit();
+			exit(1);
+#endif
+			return FALSE;
+		}
+	}
+	
+	// Destroy any existing movie playing.
+	BinkMovie_Close();
+
+	// Create an instance of the Bink video player, drawing is
+	// handled elsewhere for ingame movies.
+	//BinkMovie_CreateSurface(filename, SidebarSurface);
+	BinkMovie_CreateSurface(filename, PrimarySurface);
+	
+	if (!BinkMovie_File_Loaded()) {
+		BinkMovie_Close();
+		return FALSE;
+	}
+	
+	// Fixup position.
+	int radar_movie_width = 140;
+	int radar_movie_height = 110;
+	int xpos = ((SidebarSurface->Width-radar_movie_width)/2)+1;
+	int ypos = 27;
+	
+	// We draw to primary now, so we need to do an absolute adjustment.
+	xpos = xpos + (PrimarySurface->Width-SidebarSurface->Width);
+	
+	BinkMovie_SetPosition(xpos, ypos);
+	
+	// To make sure the video doesnt stop when the user presses the ESC key.
+	BinkBreakoutAllowed = FALSE;
+	
+	BinkIngameMovie = TRUE;
+	
+	return TRUE;
+}
+
+
+//
+// Intercept to the games Play_Ingame_Movie which checks if the Bink video file is 
+// available, falling back to VQA if not.
+//
+void __fastcall Play_Ingame_Movie_Intercept(int vqtype)
+{
+	if (vqtype == -1 || vqtype >= DynamicVectorClass_Movies_ActiveCount) {
+		return;
+	}
+	
+	// Get pointer to movie name entry
+	char **movie_name = (char *)((int)DynamicVectorClass_Movies_Vector + (vqtype * 4));
+	
+	static char filename_buffer[32];
+	strncpy(filename_buffer, *movie_name, 32);
+	
+	// Invalid filename
+    if (filename_buffer[0] == '\0') {
+        WWDebug_Printf("Invalid movie filename \"%s\"!\n", filename_buffer);
+        return;
+    }
+
+    char *upper_filename = strupr((char *)filename_buffer);
+
+    char bink_buffer[32-4];
+    sprintf(bink_buffer, "%s.BIK", upper_filename);
+	
+    char vqa_buffer[32-4];
+    sprintf(vqa_buffer, "%s.VQA", upper_filename);
+	
+    CCFileClass binkfile;
+    CCFileClass vqafile;
+	
+	CCFileClass__CCFileClass(&binkfile, bink_buffer);
+	CCFileClass__CCFileClass(&vqafile, vqa_buffer);
+	
+	BOOL bink_available = CCFileClass__Is_Available(&binkfile, FALSE);
+	BOOL vqa_available = CCFileClass__Is_Available(&vqafile, FALSE);
+	
+	// If the movie exists as a .BIK, if so, play as Bink!
+	if (bink_available) {
+		WWDebug_Printf("Play_Ingame_Movie \"%s\" as Bink!\n", upper_filename);
+		if (Play_Ingame_Movie_As_Bink(bink_buffer)) {
+			CCFileClass__Destroy(&binkfile);
+			CCFileClass__Destroy(&vqafile);
+			return;
+		}
+	}
+
+	// The movie did not exist as a .BIK, attempt to play the .VQA.
+    if (vqa_available) {
+        WWDebug_Printf("Play_Ingame_Movie \"%s\" as VQA!\n", upper_filename);
+        Play_Ingame_Movie(vqtype);	// Call the games Play_Ingame_Movie.
+		
+    } else {
+		WWDebug_Printf("Failed to play ingame movie \"%s\"!\n", upper_filename);
+	}
+
+	CCFileClass__Destroy(&binkfile);
+	CCFileClass__Destroy(&vqafile);
+}
+
+
+//
+// Handle the playback of a Bink movie on the sidebar radar.
+//
+void RadarClass_Play_Bink_Movie()
+{
+	static int _volume_percent = 40; // was 50
+	static BOOL _playing = FALSE;
+	static BOOL _volume_adjusted = FALSE;
+	static int _prev_volume;
+	
+	if (BinkIngameMovie) {
+		
+		if (!_playing) {
+			if (BinkFilename[0] != '\0') {
+				WWDebug_Printf("RadarClass_Play_Bink_Movie(%s)!\n", BinkFilename);
+			}
+			_playing = TRUE;
+		}
+		
+		// Adjust the game volume down to 50% so we can hear the radar video.
+		if (!_volume_adjusted && !Is_Speaking()) {
+			_prev_volume = DSAudio_Set_Volume_Percent(&DSAudio, _volume_percent);
+			_volume_adjusted = TRUE;
+		}
+		
+		BinkRadarDraw = TRUE;
+		
+		//WWDebug_Printf("Radar: Before BinkMovie_Advance_Frame.\n");
+		
+		BinkMovie_Advance_Frame();
+		
+		//WWDebug_Printf("Radar: After BinkMovie_Advance_Frame.\n");
+		
+		BinkRadarDraw = FALSE;
+		
+		// Has the movie finished?
+		if (BinkMovie_Has_Finished()) {
+						
+			// Restore game volume.
+			if (_volume_adjusted) {
+				DSAudio_Set_Volume_All(&DSAudio, _prev_volume);
+				_volume_adjusted = FALSE;
+			}
+			
+			WWDebug_Printf("Ingame Bink movie finished!\n");
+			
+			BinkIngameMovie = FALSE;
+			BinkBreakoutAllowed = TRUE;
+			
+			WWDebug_Printf("Restoring radar mode\n");
+			
+			RadarClass_14B4 = 5;
+			RadarClass__Radar_Activate(&MouseClass_Map, RadarClass_14BC);
+			
+			// Cleanup bink movie the player.
+			BinkMovie_Close();
+			
+			_playing = FALSE;
+		}
+	}
+}
+
+
+void __thiscall RadarClass_Play_Movie_Intercept(void *this)
+{
+	if (BinkIngameMovie) {
+		RadarClass_Play_Bink_Movie();
+	} else {
+		//WWDebug_Printf("Before RadarClass__Play_Movie.\n");
+		RadarClass__Play_Movie(this);
+		//WWDebug_Printf("After RadarClass__Play_Movie.\n");
+	}
+}
+
+
+bool Windows_Procedure_Is_Movie_Playing_Intercept()
+{
+	return BinkFullscreenMovie || BinkIngameMovie || Current_Movie_Ptr != NULL || IngameVQ_Count > 0;
+}
+
+
+void MovieClass_Update_Intercept()
+{
+	if (BinkFullscreenMovie) {
+
+		//
+		// Clear the surfaces, this fixes a issue were the game
+		// game be seen if the window moves.
+		//
+		HiddenSurface->vtable->Fill(HiddenSurface, 0);
+		//AlternateSurface->vtable->Fill(AlternateSurface, 0);
+		//CompositeSurface->vtable->Fill(CompositeSurface, 0);
+		//PrimarySurface->vtable->Fill(PrimarySurface, 0);
+		
+	} else if (BinkIngameMovie) {
+		
+		if (!BinkMovie_Has_Finished()) {
+			//WWDebug_Printf("MovieClass_Update_Intercept: Before BinkMovie_Draw_Frame.\n");
+			BinkMovie_Draw_Frame();
+			//WWDebug_Printf("MovieClass_Update_Intercept: After BinkMovie_Draw_Frame.\n");
+		} else {
+			// Cleanup bink movie the player.
+			BinkMovie_Close();
+		}
+		
+	} else {
+		//WWDebug_Printf("About to call MovieClass_Update.\n");
+		MovieClass_Update();
+	}
+}
+
+
+bool RadarClass_AI_Intercept()
+{
+	return BinkIngameMovie || IngameVQ_Count > 0;
+}
+
+
+void __fastcall Movie_Handle_Focus_Intercept(bool state)
+{
+	if (BinkFullscreenMovie || BinkIngameMovie) {
+		BinkMovie_Pause(state);
+	} else {
+		Movie_Handle_Focus(state);
+	}
+}
+
+
 void Bink_Library_Shutdown()
 {
 	// Cleanup dll imports.
@@ -162,6 +408,25 @@ CALL(0x0057FEDA, _Play_Movie_Intercept);
 CALL(0x0057FF3F, _Play_Movie_Intercept);
 CALL(0x005DB314, _Play_Movie_Intercept);
 CALL(0x005E35C8, _Play_Movie_Intercept);
+
+CALL(0x0061A90B, _Play_Ingame_Movie_Intercept);
+CALL(0x0061BF23, _Play_Ingame_Movie_Intercept);
+
+CALL(0x005B8F20, _RadarClass_Play_Movie_Intercept);
+
+CALL(0x00685CEE, _Windows_Procedure_Is_Movie_Playing_Intercept);
+
+CALL(0x00685CF7, _MovieClass_Update_Intercept);
+
+CALL(0x005B9144, _RadarClass_AI_Intercept);
+SETBYTE(0x005B914B, 0x74); // jz
+
+CALL(0x005DB52E, _Movie_Handle_Focus_Intercept);
+LJMP(0x005DB602, _Movie_Handle_Focus_Intercept);
+CALL(0x0068598F, _Movie_Handle_Focus_Intercept);
+CALL(0x00685B97, _Movie_Handle_Focus_Intercept);
+CALL(0x00685EA0, _Movie_Handle_Focus_Intercept);
+
 
 //CLEAR(0x00602467, 0x90, 0x00602474);
 CALL(0x00602474, _Bink_Library_Shutdown);

--- a/src/binkmovie/binkmovie.h
+++ b/src/binkmovie/binkmovie.h
@@ -18,7 +18,7 @@ void __fastcall BinkMovie_Close(void);
 void __fastcall BinkMovie_SetPosition(unsigned x_pos, unsigned y_pos);
 void __fastcall BinkMovie_Go_To_Frame(int frame);
 void __fastcall BinkMovie_Pause(BOOL pause);
-BOOL __fastcall BinkMovie_Has_Frames_Left(void);
+BOOL __fastcall BinkMovie_Has_Finished(void);
 BOOL __fastcall BinkMovie_Open(char * filename);
 BOOL __fastcall BinkMovie_Next_Frame(DSurface * surface, unsigned x_pos, unsigned y_pos);
 BOOL __fastcall BinkMovie_Advance_Frame(void);
@@ -27,6 +27,7 @@ void __fastcall BinkMovie_Render_Frame(DSurface * surface, unsigned x_pos, unsig
 void __fastcall BinkMovie_Destroy(void);
 BOOL __fastcall BinkMovie_ResumePause(void);
 float __fastcall BinkMovie_Set_Master_Volume(float vol);
+BOOL BinkMovie_File_Loaded();
 
 
 //
@@ -34,6 +35,10 @@ float __fastcall BinkMovie_Set_Master_Volume(float vol);
 //
 extern BOOL BinkBreakoutAllowed;
 extern BOOL BinkScaleToFit;
+extern BOOL BinkFullscreenMovie;
+extern BOOL BinkIngameMovie;
+extern BOOL BinkRadarDraw;
+extern char BinkFilename[32];
 
 
 #endif // _BINK_MOVIE_H_

--- a/sym.asm
+++ b/sym.asm
@@ -59,6 +59,9 @@ setcglob 0x007E4058, DynamicVectorClass_AircraftClass
 setcglob 0x007E4858, CurrentObjectsArray
 setcglob 0x007E485C, CurrentObjectsArray_Vector
 setcglob 0x007E4868, CurrentObjectsArray_Count
+setcglob 0x00806DD0, DynamicVectorClass_Movies
+setcglob 0x00806DD4, DynamicVectorClass_Movies_Vector
+setcglob 0x00806DE0, DynamicVectorClass_Movies_ActiveCount
 
 setcglob 0x007B345C, DynamicVectorClass_UnitClass_Array
 setcglob 0x007E2304, DynamicVectorClass_InfantryClass_Array
@@ -186,6 +189,7 @@ setcglob 0x004F0F00, IPXManagerClass__Response_Time
 setcglob 0x004EF040, IPXAddressClass__IPXAddressClass
 setcglob 0x004F07E0, IPXManagerClass__Connection_Name
 
+setcglob 0x007093C0, Radar_Movie_Playing
 setcglob 0x007E250C, MaxAhead
 setcglob 0x007E2524, MaxMaxAhead
 setcglob 0x007E2510, FrameSendRate
@@ -207,6 +211,7 @@ setcglob 0x007E4720, GameOptionsClass_GameSpeed
 setcglob 0x007E474C, GameOptionsClass_VoiceVolume
 setcglob 0x007E473C, GameOptionsClass_ScreenWidth
 setcglob 0x007E4740, GameOptionsClass_ScreenHeight
+setcglob 0x007E4744, GameOptionsClass_StretchMovies
 
 ; Scenario
 setcglob 0x007E28B8, ScenarioName
@@ -276,6 +281,12 @@ setcglob 0x00618050, Tactical_618050
 setcglob 0x0060F3C0, Tactical_AdjustForZ
 setcglob 0x0060F0F0, Tactical_60F0F0
 
+setcglob 0x005BCC40, RadarClass__Play_Movie
+setcglob 0x005BBEE0, RadarClass__Radar_Activate
+setcglob 0x00838038, IngameVQ_Count
+setcglob 0x007497FC, RadarClass_14B4;
+setcglob 0x00749804 ,RadarClass_14BC;
+
 
 ; Statistics
 setcglob 0x007E4FD0, StatisticsPacketSent
@@ -302,6 +313,7 @@ setcglob 0x00474A50, Simple_Text_Print
 setcglob 0x00685BC0, WndProc
 setcglob 0x00865040, MainWindow
 setcglob 0x007E4920, GameInFocus
+setcglob 0x007E48FC, InScenario
 
 ; Sidebar
 setcglob 0x0080C3BC, SidebarClass_Redraw_Buttons
@@ -314,9 +326,19 @@ setcglob 0x005F3560, SidebarClass__Draw_It
 setcglob 0x005F2720, SidebarClass__Init_IO
 setcglob 0x005F2900, SidebarClass__Init_For_House
 
+
 ; Audio
+setcglob 0x00489E30, DSAudio_Set_Volume_All
+setcglob 0x00489F20, DSAudio_Set_Volume_Percent
 setcglob 0x007A27CC, DSAudio_SoundObject
 setcglob 0x007A27DC, DSAudio_AudioDone
+setcglob 0x007A2448, DSAudio
+setcglob 0x00665B20, Is_Speaking
+
+setcglob 0x00806E1C, Current_Movie_Ptr
+setcglob 0x005646E0, MovieClass_Update
+setcglob 0x00563CC0, Movie_Handle_Focus
+
 
 ; Debug
 setcglob 0x007E4903, Debug_Quiet
@@ -484,7 +506,10 @@ setcglob 0x0048C140, DSurface_Conversion_Type
 setcglob 0x0069FAE0, Write_PCX_File
 
 setcglob 0x00563670, Play_Movie
+setcglob 0x00563B00, Play_Ingame_Movie
 setcglob 0x0066B230, VQA_Windows_Message_Loop
+
+setcglob 0x006CAB74, vtBSurface
 
 
 ;Address  Ordinal Name                          Library


### PR DESCRIPTION
This PR adds support for Bink video (version 1) playback in the sidebar for Tiberian Sun. It also implements scaling for fullscreen videos when ``StretchMovies`` is set to ``yes`` in ``SUN.INI``.

This system is optional, three conditions must be met for the game to play a sidebar Bink video;
- The .BIK video must exist (for example, GDI01_SB.BIK).
- The Bink library is found, BINKW32.DLL.