### PR TITLE
Fixes an issue with some cnc-ddraw setups not redrawing the sidebar when a movie is playing.

### DIFF
--- a/inc/Classes/DSurface.h
+++ b/inc/Classes/DSurface.h
@@ -7,7 +7,7 @@ typedef struct {
     void *DSurface__Destroy;
     void *Dsurface_BlitWhole;
     void (__thiscall *BlitPart)(DSurface *this, RECT *torect, DSurface *fromsurface, RECT *fromrect, bool a4, bool a5);
-    void *Blit;
+    void (__thiscall *BlitClip)(DSurface *this, RECT *toclip, RECT *torect, DSurface *fromsurface, RECT *fromclip, RECT *fromrect, bool a4, bool a5);
     void *FillRectEx;
     void *FillRect;
     void (__thiscall *Fill)(DSurface *this, int color);

--- a/src/Hook_Main_Loop.c
+++ b/src/Hook_Main_Loop.c
@@ -28,38 +28,48 @@ MainLoop_AfterRender(MessageListClass *msg) {
 	MessageListClass__Manage(msg);
 
 	if (SpawnerActive) {
-		if (PlayerPtr->Defeated == true && HaventSetSpecTeam) {
-			set_team_spec();
-			HaventSetSpecTeam = false;
-		}
+		
+		if (SessionClass_this.GameSession != 0) { // GAME_CAMPAIGN
+		
+			if (PlayerPtr->Defeated == true && HaventSetSpecTeam) {
+				set_team_spec();
+				HaventSetSpecTeam = false;
+			}
 
-		if (IntegrateMumbleSun && IntegrateMumbleSpawn) {
-			updateMumble();
-		}
+			if (IntegrateMumbleSun && IntegrateMumbleSpawn) {
+				updateMumble();
+			}
 
-		if (IsHost &&
-			AutoSaveGame > 0 && Frame >= NextAutoSave)
-		{
-			NextAutoSave = Frame + AutoSaveGame;
-			EventClass e;
-			EventClass__EventClass_noarg(&e, PlayerPtr->ID, EVENTTYPE_SAVEGAME);
-			EventClass__EnqueueEvent(&e);
-		}
+			if (IsHost &&
+				AutoSaveGame > 0 && Frame >= NextAutoSave)
+			{
+				NextAutoSave = Frame + AutoSaveGame;
+				EventClass e;
+				EventClass__EventClass_noarg(&e, PlayerPtr->ID, EVENTTYPE_SAVEGAME);
+				EventClass__EnqueueEvent(&e);
+			}
 
-		if (UseProtocolZero && Frame >= ResponseTimeFrame)
-		{
-			ResponseTimeFrame = Frame + ResponseTimeInterval;
-			Send_Response_Time();
-		}
+			if (UseProtocolZero && Frame >= ResponseTimeFrame)
+			{
+				ResponseTimeFrame = Frame + ResponseTimeInterval;
+				Send_Response_Time();
+			}
 
-		if (RunAutoSS && SessionClass_this.GameSession == 3 && Frame > NextAutoSS)
-		{
-			DoingAutoSS = 1;
-			ScreenCaptureCommandClass_Execute();
-			DoingAutoSS = 0;
-			NextAutoSS = Frame + AutoSSInterval * 60; //60fps
-			if (AutoSSInterval < AutoSSIntervalMax)
-				AutoSSInterval += AutoSSGrowth;
+			if (RunAutoSS && SessionClass_this.GameSession == 3 && Frame > NextAutoSS)
+			{
+				DoingAutoSS = 1;
+				ScreenCaptureCommandClass_Execute();
+				DoingAutoSS = 0;
+				NextAutoSS = Frame + AutoSSInterval * 60; //60fps
+				if (AutoSSInterval < AutoSSIntervalMax)
+					AutoSSInterval += AutoSSGrowth;
+			}
+			
+			if (DumpDebugInfoFrame == Frame)
+			{
+				Print_CRCs(0);
+			}
+			
 		}
 
 		if (DoScreenshotOnceThenExit && DoScreenshotOnceThenExitFrame == Frame)
@@ -73,11 +83,6 @@ MainLoop_AfterRender(MessageListClass *msg) {
 
 		if (ReplayPlayback) {
 			Replay_Read_Frame_Func();
-		}
-
-		if (DumpDebugInfoFrame == Frame)
-		{
-			Print_CRCs(0);
 		}
 	}
 }

--- a/src/binkmovie/bink_asm_patches.asm
+++ b/src/binkmovie/bink_asm_patches.asm
@@ -22,24 +22,24 @@ cextern IngameVQ_Count
 ;
 _Windows_Procedure_Should_Blit_Patch_asm_patch:
 	cmp byte [InScenario], 1
-	jnz .move_update
+	jnz .movie_update
 
 	mov edx, dword [BinkFullscreenMovie]
 	test edx, edx
-	jnz .move_update
+	jnz .movie_update
 
 	mov edx, dword [Current_Movie_Ptr]
 	test edx, edx
-	jnz .move_update
+	jnz .movie_update
 
 	mov edx, dword [IngameVQ_Count]
 	cmp edx, 1
-	jge .move_update
+	jge .movie_update
 	
 	; Blit game layer.
 	mov eax, dword [CompositeSurface]
 	jmp 0x00685CC2
 	
 	; Update a movie
-.move_update:
+.movie_update:
 	jmp 0x00685CEE

--- a/src/binkmovie/binkmovie.h
+++ b/src/binkmovie/binkmovie.h
@@ -40,5 +40,8 @@ extern BOOL BinkIngameMovie;
 extern BOOL BinkRadarDraw;
 extern char BinkFilename[32];
 
+extern int BinkXPos;
+extern int BinkYPos;
+
 
 #endif // _BINK_MOVIE_H_


### PR DESCRIPTION
Fixes an issue with some cnc-ddraw setups not redrawing the sidebar when a movie is playing. It effectively forces a blit to the PrimarySurface before the surfaces are updated.