### PR TITLE
Adds patch for enforcing a the lowest resolution.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ COMMON_OBJS = \
               src/exception_catch.o \
               src/force_conversion_type.o \
               src/video_mode_hacks.o \
+              src/enforce_lower_resolution_limit.o \
               src/binkmovie/bink_load_dll.o \
               src/binkmovie/bink_patches.o \
               src/binkmovie/bink_asm_patches.o \

--- a/inc/TiberianSun.inc
+++ b/inc/TiberianSun.inc
@@ -42,6 +42,8 @@ cextern EasyShroud
 cextern AutoSaveGame
 cextern NextAutoSave
 cextern NormalizedDelayGameSpeed;
+cextern GameOptionsClass_ScreenWidth;
+cextern GameOptionsClass_ScreenHeight;
 
 cextern CoachMode
 cextern HouseClass__Is_Ally_Or_Spec_HH

--- a/src/enforce_lower_resolution_limit.asm
+++ b/src/enforce_lower_resolution_limit.asm
@@ -1,0 +1,73 @@
+;
+; Patch to enforce a lower resolution limit.
+;
+; Author: CCHyper
+;
+%include "TiberianSun.inc"
+%include "macros/patch.inc"
+%include "macros/datatypes.inc"
+
+gint FORCE_WIDTH_MIN, 640  ; The lowest screen width the user can set.
+gint FORCE_HEIGHT_MIN, 400 ; The lowest screen height the user can set.
+
+@LJMP 0x00589E46, _OptionsClass_Load_Settings_Enforce_Lower_Resolution_Limit
+@LJMP 0x00601128, _WinMain_Enforce_Lower_Resolution_Limit
+
+_OptionsClass_Load_Settings_Enforce_Lower_Resolution_Limit:
+
+.check_width:
+	cmp dword [GameOptionsClass_ScreenWidth], FORCE_WIDTH_MIN
+	jge .check_height
+	
+	mov eax, dword [FORCE_WIDTH_MIN]
+	mov dword [GameOptionsClass_ScreenWidth], eax
+	
+.check_height:
+	cmp dword [GameOptionsClass_ScreenHeight], FORCE_HEIGHT_MIN
+	jge .out
+	
+	mov eax, dword [FORCE_HEIGHT_MIN]
+	mov dword [GameOptionsClass_ScreenHeight], eax
+	
+.out:
+	; stolen bytes
+	mov [esi+20h], eax
+	mov ecx, [esi+1Ch]
+	push eax
+	push ecx
+	push 0x00706D74 ; "Resolution = %d X %d\n"
+	call 0x004082D0 ; WWDebug_Printf()
+
+	jmp 0x00589E58
+
+
+_WinMain_Enforce_Lower_Resolution_Limit:
+
+	; stolen bytes
+	mov dword [GameOptionsClass_ScreenHeight], eax
+
+.check_width:
+	cmp dword [GameOptionsClass_ScreenWidth], FORCE_WIDTH_MIN
+	jge .check_height
+	
+	mov eax, dword [FORCE_WIDTH_MIN]
+	mov dword [GameOptionsClass_ScreenWidth], eax
+	
+.check_height:
+	cmp dword [GameOptionsClass_ScreenHeight], FORCE_HEIGHT_MIN
+	jge .out
+	
+	mov eax, dword [FORCE_HEIGHT_MIN]
+	mov dword [GameOptionsClass_ScreenHeight], eax
+	
+.out:
+	mov ecx, dword [GameOptionsClass_ScreenWidth]
+	mov eax, dword [GameOptionsClass_ScreenHeight]
+	push eax
+	push ecx
+	push 0x00706D74 ; "Resolution = %d X %d\n"
+	call 0x004082D0 ; WWDebug_Printf()
+	
+	add esp, 0Ch
+
+	jmp 0x0060112D

--- a/src/mods/dta/dta.mk
+++ b/src/mods/dta/dta.mk
@@ -180,6 +180,7 @@ DTA_OBJS = \
                     src/write_jpg_png.o \
                     src/replays/replays.o \
                     src/replays/replay_game_patches.o \
+                    src/enforce_lower_resolution_limit.o \
                     src/binkmovie/bink_load_dll.o \
                     src/binkmovie/bink_patches.o \
                     src/binkmovie/bink_asm_patches.o \

--- a/src/mods/ti/ti.mk
+++ b/src/mods/ti/ti.mk
@@ -161,6 +161,7 @@ TI_OBJS = \
                     src/mods/no_crate_respawn_with_crates_disabled.o \
                     src/mods/ti/team_number_position.o \
                     src/mods/ti/waypoint_enhancements.o \
+                    src/enforce_lower_resolution_limit.o \
                     src/binkmovie/bink_load_dll.o \
                     src/binkmovie/bink_patches.o \
                     src/binkmovie/bink_asm_patches.o \

--- a/src/mods/to/to.mk
+++ b/src/mods/to/to.mk
@@ -157,6 +157,7 @@ TO_OBJS = \
                     src/write_jpg_png.o \
                     src/replays/replays.o \
                     src/replays/replay_game_patches.o \
+                    src/enforce_lower_resolution_limit.o \
                     src/binkmovie/bink_load_dll.o \
                     src/binkmovie/bink_patches.o \
                     src/binkmovie/bink_asm_patches.o \

--- a/src/mods/tsclient/tsclient.mk
+++ b/src/mods/tsclient/tsclient.mk
@@ -150,6 +150,7 @@ TSCLIENT_OBJS = \
                     src/write_jpg_png.o \
                     src/replays/replays.o \
                     src/replays/replay_game_patches.o \
+                    src/enforce_lower_resolution_limit.o \
                     src/binkmovie/bink_load_dll.o \
                     src/binkmovie/bink_patches.o \
                     src/binkmovie/bink_asm_patches.o \


### PR DESCRIPTION
This PR adds a patch for enforcing the lowest resolution a user can set;

By default, the normal TS behaviour will happen, but if the developer chooses, he can set a low limit in ``enforce_lower_resolution_limit.asm`` with the FORCE_WIDTH_MIN and FORCE_HEIGHT_MIN defines.

For example, setting these two values to 1024 and 768 respectively will force users to that resolution if they attempt to launch the game with a resolution lower than this.